### PR TITLE
Add notes consumption for NoAuth account

### DIFF
--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -31,7 +31,7 @@ pub async fn deploy() -> anyhow::Result<()> {
         Felt::new(0),
     ].to_vec())?;
     let init_note = create_note_for_naming("initialize_naming".to_string(), initialize_inputs, deployer_account.id(), naming_account.id(), NoteAssets::new(vec![]).unwrap()).await?;
-    
+
     let init_req = TransactionRequestBuilder::new()
         .own_output_notes(vec![OutputNote::Full(init_note)])
         .build()?;
@@ -82,6 +82,35 @@ pub async fn deploy() -> anyhow::Result<()> {
     sleep(Duration::from_secs(6)).await;
 
     client.sync_state().await?;
+
+    // Consume notes explicitly (required for NoAuth accounts)
+    println!("Consuming initialization notes...");
+    let consumable_notes = client.get_consumable_notes(Some(naming_account.id())).await?;
+
+    if !consumable_notes.is_empty() {
+        println!("Found {} consumable note(s)", consumable_notes.len());
+
+        let note_ids: Vec<_> = consumable_notes.iter().map(|(record, _)| (record.id(), None)).collect();
+
+        let nop_script_code = std::fs::read_to_string(std::path::Path::new("./masm/scripts/nop.masm"))?;
+        use miden_client::ScriptBuilder;
+        let transaction_script = ScriptBuilder::new(false)
+            .compile_tx_script(nop_script_code)?;
+
+        let consume_request = TransactionRequestBuilder::new()
+            .authenticated_input_notes(note_ids)
+            .custom_script(transaction_script)
+            .build()?;
+
+        let consume_tx_id = client.submit_new_transaction(naming_account.id(), consume_request).await?;
+        println!("Consuming notes via transaction: {:?}", consume_tx_id);
+
+        wait_for_tx(&mut client, consume_tx_id).await?;
+        println!("✅ Notes consumed successfully!");
+    } else {
+        println!("Warning: No consumable notes found");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
In account.rs naming account is created with NoAuth component which prevent note consumption :

```
let account = AccountBuilder::new(seed)
        .account_type(AccountType::RegularAccountImmutableCode)
        .storage_mode(AccountStorageMode::Public)
        .with_component(account_component.clone())
        .with_auth_component(NoAuth)
        .build()?;
```

So it requires to have note consume explicitly.