### PR TITLE
fix: remove redundant clone in create_naming_account

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -62,7 +62,7 @@ pub async fn create_naming_account(
     let account = AccountBuilder::new(seed)
         .account_type(AccountType::RegularAccountImmutableCode)
         .storage_mode(AccountStorageMode::Network)
-        .with_component(account_component.clone())
+        .with_component(account_component)
         .with_auth_component(NoAuth)
         .build()?;
 


### PR DESCRIPTION
Remove unnecessary clone() call when passing account_component to with_component().
The method takes ownership, and the variable is not used afterwards, making the clone redundant.
This matches the pattern used elsewhere in the codebase (e.g., test_utils.rs).