### PR TITLE
Implement claim_protocol_revenue, withdraw_assets and add transfer/protocol tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Miden Name is actively developed and any functionality can be changed, removed, 
 - **Discount System**: Multi-year registrations get discounts (3+ years: 30%, 5+ years: 50%)
 - **Referral System**: Referrers earn a percentage of registration fees
 - **Revenue Tracking**: Protocol tracks total and claimable revenue per token
-- **Owner Controls**: Registry owner can update prices, set referral rates, and claim revenue
+- **Revenue Claiming**: Owner can claim accumulated protocol revenue (updates claimed tracker)
+- **Asset Withdrawal**: Owner can withdraw the full token balance to any account
+- **Owner Controls**: Registry owner can update prices, set referral rates, claim revenue, withdraw assets, and transfer ownership
 - **Expired Domain Cleanup**: Permissionless function to clear expired domain mappings
 
 If you are learning Miden as a developer, you can find practices for the following examples:
@@ -32,6 +34,7 @@ If you are learning Miden as a developer, you can find practices for the followi
 - Note-based transaction system
 - Ownership and access control patterns
 - Payment validation and asset handling
+- Output note creation and asset withdrawal from contract vaults
 - Time-based logic (domain expiry)
 - Referral and revenue distribution systems
 - Storage optimization techniques
@@ -46,7 +49,7 @@ All core logic is implemented in Miden Assembly (`.masm` files):
 
 - **[naming.masm](masm/accounts/naming.masm)**: Main name registry contract
   - Storage slots (see Storage Layout section below)
-  - Exports: `register`, `register_with_referrer`, `activate_domain`, `transfer`, `extend_domain`, `clear_expired_domain`, `init`, `receive_asset`, `update_registry_owner`, `set_price`, `set_referrer_rate`, `claim_protocol_revenue`
+  - Exports: `register`, `register_with_referrer`, `activate_domain`, `transfer`, `extend_domain`, `clear_expired_domain`, `init`, `receive_asset`, `update_registry_owner`, `set_price`, `set_referrer_rate`, `claim_protocol_revenue`, `withdraw_assets`
 
 - **[identity.masm](masm/accounts/identity.masm)**: Identity contract for user profiles (under development)
 
@@ -65,6 +68,7 @@ Note scripts enable cross-account interactions and contract calls:
 - **[set_all_prices_testnet.masm](masm/notes/set_all_prices_testnet.masm)**: Set test prices for testnet
 - **[set_referrer_rate.masm](masm/notes/set_referrer_rate.masm)**: Set referral commission rate
 - **[claim_protocol_revenue.masm](masm/notes/claim_protocol_revenue.masm)**: Claim accumulated protocol revenue
+- **[withdraw_assets.masm](masm/notes/withdraw_assets.masm)**: Withdraw full token balance from contract vault
 - **[transfer_ownership.masm](masm/notes/transfer_ownership.masm)**: Transfer registry ownership
 - **[P2N.masm](masm/notes/P2N.masm)**: Pay-to-note for payment handling
 
@@ -240,7 +244,7 @@ The naming contract uses Miden's storage system with numbered slots:
 - **Multiple domains per account**: Accounts can own unlimited domains
 - **Unique active domains**: Only one account can have an active mapping per domain
 - **Registration period**: 1-10 years per registration
-- **Owner-only operations**: Price updates, referral rates, ownership transfer, revenue claims
+- **Owner-only operations**: Price updates, referral rates, ownership transfer, revenue claims, asset withdrawals
 - **Domain ownership**: Registration creates ownership; activation creates account mapping
 - **Expiry enforcement**: Expired domains can be cleared permissionlessly
 - **Referral rate limit**: Maximum 25% (2500 basis points)
@@ -257,20 +261,50 @@ The naming contract uses Miden's storage system with numbered slots:
 
 ## Testing
 
-Tests validate the following functionality:
+Run all tests:
 
-- Registry initialization
-- Domain registration with payment
-- Domain activation and mapping
-- Domain transfer between accounts
-- Domain expiry and extension
-- Expired domain cleanup
-- Referral system and revenue distribution
-- Multi-year discounts
-- Protocol revenue tracking
-- Owner controls (price updates, referral rates)
-- Domain encoding/decoding
-- Access control enforcement
+```bash
+cargo test -- --nocapture
+```
+
+### Test Coverage (33 active tests, 2 ignored)
+
+#### Encoding Tests (`encoding_test.rs` — 5 tests)
+- Domain name encoding/decoding (single & multi-felt)
+
+#### Registration Tests (`naming_register_tests.rs` — 11 tests)
+- Registry initialization and owner setup
+- Domain registration with payment validation (exact, excess, insufficient amounts)
+- Domain activation and bidirectional mapping
+- Activation rejected for non-owner
+- Duplicate domain registration rejected (same & different owners)
+- Multiple domains registration and activation
+- Domain length validation (empty, too long, wrong character count)
+
+#### Transfer Tests (`naming_transfer_tests.rs` — 12 tests)
+- Domain transfer: happy path, clears old mappings
+- Domain transfer then reactivation by new owner
+- Domain transfer rejected for non-owner
+- Transfer of nonexistent domain rejected
+- Transfer preserves unrelated domains
+- Activate then transfer clears activation mappings
+- Chain transfer A→B→C
+- Circular transfer A→B→A with re-activation
+- Registry ownership transfer: happy path
+- Registry ownership transfer rejected for non-owner
+- New owner gains admin privileges (set_prices)
+- Old owner loses admin privileges after transfer
+
+#### Protocol Tests (`naming_protocol_tests.rs` — 5 tests)
+- Double initialization rejected
+- Dynamic price update with testnet prices script
+- Revenue accumulates across multiple registrations
+- Protocol revenue claiming (claim_protocol_revenue)
+- Full balance withdrawal (withdraw_assets)
+
+#### Referral Tests (`naming_referral_tests.rs` — 2 ignored)
+- ~~Register with referrer~~ *(requires naming_discount contract)*
+- ~~Referrer revenue accumulation~~ *(requires naming_discount contract)*
 
 ## Resources
 

--- a/masm/accounts/naming.masm
+++ b/masm/accounts/naming.masm
@@ -195,28 +195,45 @@ pub proc claim_protocol_revenue
     mem_storew_be.MEM_NOTE_DETAILS dropw
     mem_storew_be.MEM_RECIPIENT dropw
     exec._assert_only_owner
-    # Create note
-
-
+    # Create output note
     padw mem_loadw_be.MEM_RECIPIENT
     padw mem_loadw_be.MEM_NOTE_DETAILS
-    #padw mem_loadw_be.MEM_PAYMENT_TOKEN
-    # Stack must be
-    # [tag, aux, note_type, exec_hint, RECIPIENT]
-    exec.output_note::create # TODO
-    # Create ASSET word
-    # []
+    drop drop
+    # [tag, note_type, RECIPIENT]
+    exec.output_note::create
+    # [note_idx]
     exec._get_remaining_revenue
-    # [claimable_revenue]
+    # [claimable_revenue, note_idx]
     exec._get_asset
-    # [ASSET]
+    # [ASSET, note_idx]
+    exec.native_account::remove_asset
+    # [ASSET, note_idx]
+    exec.output_note::add_asset
+    # []
+    exec._set_claimed_to_total
 end
 
-# Input: [TOKEN]
+# Input: [TOKEN, NOTE_DETAILS, RECIPIENT]
 pub proc withdraw_assets
     mem_storew_be.MEM_PAYMENT_TOKEN dropw
+    mem_storew_be.MEM_NOTE_DETAILS dropw
+    mem_storew_be.MEM_RECIPIENT dropw
     exec._assert_only_owner
-    nop
+    # Create output note
+    padw mem_loadw_be.MEM_RECIPIENT
+    padw mem_loadw_be.MEM_NOTE_DETAILS
+    drop drop
+    # [tag, note_type, RECIPIENT]
+    exec.output_note::create
+    # [note_idx]
+    exec._get_balance
+    # [balance, note_idx]
+    exec._get_asset
+    # [ASSET, note_idx]
+    exec.native_account::remove_asset
+    # [ASSET, note_idx]
+    exec.output_note::add_asset
+    # []
 end
 
 # Internal Methods
@@ -267,12 +284,25 @@ proc _get_remaining_revenue
     # [claimable_revenue]
 end
 
+# Input: [] Memory [PAYMENT_TOKEN]
+# Output: []
+# Sets claimed_revenue = total_revenue for the token
+proc _set_claimed_to_total
+    padw mem_loadw_be.MEM_PAYMENT_TOKEN
+    push.TOTAL_REVENUE_SLOT[0..2] exec.active_account::get_map_item
+    # [TOTAL_VALUE]
+    padw mem_loadw_be.MEM_PAYMENT_TOKEN
+    push.CLAIMED_REVENUE_SLOT[0..2] exec.native_account::set_map_item dropw
+end
+
 # Input: [amt] Memory [PAYMENT_TOKEN]
-# Output: [ASSET]
+# Output: [ASSET] where ASSET = [prefix, suffix, 0, amt] on stack
+# Word format: [amt, 0, suffix, prefix] matching FungibleAsset encoding
 proc _get_asset
-    push.0 swap
     padw mem_loadw_be.MEM_PAYMENT_TOKEN drop drop
-    # [prefix, suffix, amt, 0]
+    # [prefix, suffix, amt]
+    push.0 movdn.2
+    # [prefix, suffix, 0, amt]
 end
 
 # Input: [account_prefix, account_suffix] Memory [DOMAIN]

--- a/masm/notes/withdraw_assets.masm
+++ b/masm/notes/withdraw_assets.masm
@@ -1,0 +1,17 @@
+use miden_name::naming
+use miden::protocol::active_note
+use miden::core::sys
+
+const RECIPIENT=0
+const NOTE_DETAILS=4
+const TOKEN=8
+
+begin
+    push.0
+    exec.active_note::get_inputs drop drop
+
+    mem_loadw_be.RECIPIENT padw mem_loadw_be.NOTE_DETAILS padw mem_loadw_be.TOKEN
+    # [TOKEN, DETAILS, RECIPIENT]
+    call.naming::withdraw_assets
+    exec.sys::truncate_stack
+end

--- a/tests/naming_protocol_tests.rs
+++ b/tests/naming_protocol_tests.rs
@@ -1,67 +1,302 @@
 mod test_utils;
 
-use std::any::Any;
-
-use miden_client::{asset::FungibleAsset, note::{NoteAssets, NoteInputs, NoteTag, NoteType}, transaction::OutputNote};
-use miden_crypto::{Felt, Word, rand::RpoRandomCoin};
-use miden_standards::note::create_p2id_note;
-use midenname_contracts::domain::{encode_domain, encode_domain_as_felts, unsafe_encode_domain};
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
+use miden_client::{asset::FungibleAsset, note::{NoteAssets, NoteInputs, NoteTag, NoteType}};
+use miden_crypto::{Felt, Word};
+use midenname_contracts::domain::encode_domain_as_felts;
+use midenname_contracts::storage::slot_name;
 use test_utils::init_naming;
 
-use crate::test_utils::{add_note_to_builder, create_note_for_naming, create_p2id_note_exact, execute_note, execute_notes_and_build_chain};
+use miden_client::transaction::OutputNote;
+use crate::test_utils::{add_note_to_builder, create_note_for_naming, create_note_for_naming_with_custom_serial_num, create_p2id_note_exact, execute_note, execute_note_with_expected_output, execute_notes_and_build_chain};
 
 #[tokio::test]
-#[ignore = "not implemented"]
+async fn test_double_init_fails() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    // Create a second init note with custom serial to avoid NoteId collision
+    let init_inputs = NoteInputs::new([
+        Felt::new(ctx.owner.id().suffix().as_int()),
+        Felt::new(ctx.owner.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+    ].to_vec())?;
+    let second_init_note = create_note_for_naming_with_custom_serial_num(
+        "initialize_naming".to_string(), init_inputs, ctx.owner.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+        Word::new([Felt::new(99), Felt::new(0), Felt::new(0), Felt::new(0)]),
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, second_init_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id()],
+        &mut ctx.naming,
+    ).await?;
+
+    // Second init should fail
+    let result = execute_note(&mut chain, second_init_note.id(), &mut ctx.naming).await;
+    assert!(result.is_err(), "Expected double initialization to fail, but it succeeded");
+
+    // Init flag is still 1
+    let init_flag = ctx.naming.storage().get_item(&slot_name("naming::init_flag"))?;
+    assert_eq!(init_flag.get(0).unwrap().as_int(), 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_prices_updated_with_testnet_script() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    // Send testnet prices (different from default) — use custom serial_num to avoid collision
+    let price_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        Felt::new(ctx.fungible_asset.faucet_id().prefix().into()),
+    ].to_vec())?;
+    let testnet_prices_note = create_note_for_naming_with_custom_serial_num(
+        "set_all_prices_testnet".to_string(), price_inputs, ctx.owner.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+        Word::new([Felt::new(10), Felt::new(0), Felt::new(0), Felt::new(0)]),
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, testnet_prices_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id()],
+        &mut ctx.naming,
+    ).await?;
+
+    // Verify original prices (4-letter = 555)
+    let price_key = Word::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(4),
+        Felt::new(0),
+    ]);
+    let price_before = ctx.naming.storage().get_map_item(&slot_name("naming::prices"), price_key)?;
+    assert_eq!(price_before.get(0).unwrap().as_int(), 555);
+
+    // Apply testnet prices
+    execute_note(&mut chain, testnet_prices_note.id(), &mut ctx.naming).await?;
+
+    // Verify testnet prices: 4-letter = 55_000_000
+    let price_after = ctx.naming.storage().get_map_item(&slot_name("naming::prices"), price_key)?;
+    assert_eq!(price_after.get(0).unwrap().as_int(), 55_000_000);
+
+    // Verify other testnet prices
+    let price_1 = ctx.naming.storage().get_map_item(&slot_name("naming::prices"),
+        Word::new([Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()), ctx.fungible_asset.faucet_id().prefix().as_felt(), Felt::new(1), Felt::new(0)]))?;
+    assert_eq!(price_1.get(0).unwrap().as_int(), 375_000_000);
+
+    let price_5 = ctx.naming.storage().get_map_item(&slot_name("naming::prices"),
+        Word::new([Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()), ctx.fungible_asset.faucet_id().prefix().as_felt(), Felt::new(5), Felt::new(0)]))?;
+    assert_eq!(price_5.get(0).unwrap().as_int(), 20_000_000);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_revenue_accumulates_across_registrations() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    // Register "test" (4 letters, cost=555) as registrar_1
+    let domain1 = encode_domain_as_felts("test".to_string());
+    let register1_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0), Felt::new(0),
+        domain1[0], domain1[1], domain1[2], domain1[3],
+    ].to_vec())?;
+    let cost1 = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register1_note = create_note_for_naming(
+        "register_name".to_string(), register1_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost1.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register1_note.clone())?;
+
+    // Register "alpha" (5 letters, cost=123) as registrar_2
+    let domain2 = encode_domain_as_felts("alpha".to_string());
+    let register2_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0), Felt::new(0),
+        domain2[0], domain2[1], domain2[2], domain2[3],
+    ].to_vec())?;
+    let cost2 = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 123)?;
+    let register2_note = create_note_for_naming(
+        "register_name".to_string(), register2_inputs, ctx.registrar_2.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost2.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register2_note.clone())?;
+
+    // Register "hey" (3 letters, cost=789) as registrar_3
+    let domain3 = encode_domain_as_felts("hey".to_string());
+    let register3_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0), Felt::new(0),
+        domain3[0], domain3[1], domain3[2], domain3[3],
+    ].to_vec())?;
+    let cost3 = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 789)?;
+    let register3_note = create_note_for_naming(
+        "register_name".to_string(), register3_inputs, ctx.registrar_3.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost3.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register3_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register1_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, register2_note.id(), &mut ctx.naming).await?;
+    execute_note(&mut chain, register3_note.id(), &mut ctx.naming).await?;
+
+    // Assert: total_revenue = 555 + 123 + 789 = 1467
+    let revenue_key = Word::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        Felt::new(ctx.fungible_asset.faucet_id().prefix().into()),
+        Felt::new(0), Felt::new(0),
+    ]);
+    let total_revenue = ctx.naming.storage().get_map_item(&slot_name("naming::total_revenue"), revenue_key)?;
+    assert_eq!(total_revenue.get(0).unwrap().as_int(), 555 + 123 + 789);
+
+    // Assert: domain_count = 3
+    let domain_count = ctx.naming.storage().get_item(&slot_name("naming::domain_count"))?;
+    assert_eq!(domain_count.get(0).unwrap().as_int(), 3);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_claim_protocol_revenue() -> anyhow::Result<()> {
     let mut ctx = init_naming().await?;
-    println!("\nOwner prefix: {}, suffix: {}", ctx.owner.id().prefix().to_string(), ctx.owner.id().suffix().to_string());
-    println!("Naming prefix: {}, suffix: {}", ctx.naming.id().prefix().to_string(), ctx.naming.id().suffix().to_string());
-    // Register domain to increase protocol revenue
+
+    // Register "test" (4 letters, cost=555) to generate revenue
     let domain = encode_domain_as_felts("test".to_string());
     let register_note_inputs = NoteInputs::new([
         Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
         ctx.fungible_asset.faucet_id().prefix().as_felt(),
-        Felt::new(0),
-        Felt::new(0),
-        domain[0],
-        domain[1],
-        domain[2],
-        domain[3],
-        Felt::new(1), // register length
-        Felt::new(0),
-        Felt::new(0),
-        Felt::new(0),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
     ].to_vec())?;
-    
     let cost = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
-    let register_asset = NoteAssets::new(vec![cost.into()])?;
-    let register_note = create_note_for_naming("register_name".to_string(), register_note_inputs, ctx.registrar_1.id(), ctx.naming.id(), register_asset.clone()).await?;
-    
+    let register_note = create_note_for_naming(
+        "register_name".to_string(), register_note_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost.into()])?,
+    ).await?;
     add_note_to_builder(&mut ctx.builder, register_note.clone())?;
 
-    let p2id_note = create_p2id_note_exact(ctx.naming.id(), ctx.owner.id(), vec![cost.into()], NoteType::Public, Word::default())?;
+    // Build P2ID recipient targeting the owner
+    let p2id_note = create_p2id_note_exact(
+        ctx.naming.id(), ctx.owner.id(), vec![cost.into()],
+        NoteType::Public, Word::default(),
+    )?;
     let p2id_recipient = p2id_note.recipient().digest();
-    
-    let withdraw_note_inputs = NoteInputs::new([
-        p2id_recipient[0],
-        p2id_recipient[1],
-        p2id_recipient[2],
-        p2id_recipient[3],
+    let tag = NoteTag::with_account_target(ctx.owner.id());
+
+    // Note inputs: RECIPIENT (pos 0-3), NOTE_DETAILS (pos 4-7), TOKEN (pos 8-11)
+    // After mem_loadw_be, NOTE_DETAILS = [pos7, pos6, pos5, pos4]
+    // Contract drops bottom 2, leaving [pos7, pos6] = [tag, note_type]
+    let claim_note_inputs = NoteInputs::new([
+        // RECIPIENT (positions 0-3)
+        p2id_recipient[0], p2id_recipient[1], p2id_recipient[2], p2id_recipient[3],
+        // NOTE_DETAILS (positions 4-7): note_type, tag, padding, padding
+        // After mem_loadw_be: [pos7, pos6, pos5, pos4] = [0, 0, tag, note_type]
+        // After drop drop: [tag, note_type] which is what output_note::create needs
         NoteType::Public.into(),
-        NoteTag::with_account_target(ctx.naming.id()).into(),
+        tag.into(),
+        Felt::new(0), Felt::new(0),
+        // TOKEN (positions 8-11): suffix, prefix, 0, 0
         Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
         Felt::new(ctx.fungible_asset.faucet_id().prefix().into()),
-        Felt::new(0),
-        Felt::new(0),
+        Felt::new(0), Felt::new(0),
     ].to_vec())?;
-    let withdraw_note = create_note_for_naming("claim_protocol_revenue".to_string(), withdraw_note_inputs.clone(), ctx.owner.id(), ctx.naming.id(), NoteAssets::new(vec![])?).await?;
-    add_note_to_builder(&mut ctx.builder, withdraw_note.clone())?;
-    
-    let mut chain = execute_notes_and_build_chain(ctx.builder, &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()], &mut ctx.naming).await?;
+    let claim_note = create_note_for_naming(
+        "claim_protocol_revenue".to_string(), claim_note_inputs, ctx.owner.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, claim_note.clone())?;
 
-    execute_note(&mut chain, withdraw_note.id(), &mut ctx.naming).await?;
-    // check balances
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note_with_expected_output(
+        &mut chain, claim_note.id(), &mut ctx.naming,
+        vec![OutputNote::Full(p2id_note)],
+    ).await?;
+
+    // Assert: claimed_revenue = total_revenue = 555
+    let revenue_key = Word::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        Felt::new(ctx.fungible_asset.faucet_id().prefix().into()),
+        Felt::new(0), Felt::new(0),
+    ]);
+    let total_revenue = ctx.naming.storage().get_map_item(&slot_name("naming::total_revenue"), revenue_key)?;
+    assert_eq!(total_revenue.get(0).unwrap().as_int(), 555);
+    let claimed_revenue = ctx.naming.storage().get_map_item(&slot_name("naming::claimed_revenue"), revenue_key)?;
+    assert_eq!(claimed_revenue.get(0).unwrap().as_int(), 555);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_withdraw_assets() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    // Register "test" (4 letters, cost=555) to add assets to the naming vault
+    let domain = encode_domain_as_felts("test".to_string());
+    let register_note_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let cost = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(), register_note_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    // Build P2ID recipient targeting the owner for the full balance withdrawal
+    let p2id_note = create_p2id_note_exact(
+        ctx.naming.id(), ctx.owner.id(), vec![cost.into()],
+        NoteType::Public, Word::default(),
+    )?;
+    let p2id_recipient = p2id_note.recipient().digest();
+    let tag = NoteTag::with_account_target(ctx.owner.id());
+
+    // Note inputs: RECIPIENT (pos 0-3), NOTE_DETAILS (pos 4-7), TOKEN (pos 8-11)
+    let withdraw_note_inputs = NoteInputs::new([
+        // RECIPIENT (positions 0-3)
+        p2id_recipient[0], p2id_recipient[1], p2id_recipient[2], p2id_recipient[3],
+        // NOTE_DETAILS (positions 4-7): note_type, tag, padding, padding
+        NoteType::Public.into(),
+        tag.into(),
+        Felt::new(0), Felt::new(0),
+        // TOKEN (positions 8-11): suffix, prefix, 0, 0
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        Felt::new(ctx.fungible_asset.faucet_id().prefix().into()),
+        Felt::new(0), Felt::new(0),
+    ].to_vec())?;
+    let withdraw_note = create_note_for_naming(
+        "withdraw_assets".to_string(), withdraw_note_inputs, ctx.owner.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, withdraw_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note_with_expected_output(
+        &mut chain, withdraw_note.id(), &mut ctx.naming,
+        vec![OutputNote::Full(p2id_note)],
+    ).await?;
+
     Ok(())
 }

--- a/tests/naming_transfer_tests.rs
+++ b/tests/naming_transfer_tests.rs
@@ -1,0 +1,718 @@
+mod test_utils;
+
+use miden_client::{asset::FungibleAsset, note::{NoteAssets, NoteInputs}};
+use miden_crypto::{Felt, Word};
+use midenname_contracts::domain::{encode_domain, encode_domain_as_felts};
+use midenname_contracts::storage::slot_name;
+use test_utils::init_naming;
+
+use crate::test_utils::{add_note_to_builder, create_note_for_naming, create_note_for_naming_with_custom_serial_num, execute_note, execute_notes_and_build_chain};
+
+// ─── Domain transfer tests ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_transfer_domain_happy_path() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    let domain = encode_domain_as_felts("test".to_string());
+    let domain_word = encode_domain("test".to_string());
+
+    // Register "test" as registrar_1
+    let register_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0),
+        Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let cost = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(), register_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    // Transfer "test" from registrar_1 to registrar_2
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_2.id().suffix().as_int()),
+        Felt::new(ctx.registrar_2.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
+
+    // Assert: domain_to_owner = registrar_2
+    let domain_owner = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
+    assert_eq!(domain_owner.get(0).unwrap().as_int(), ctx.registrar_2.id().suffix().as_int());
+    assert_eq!(domain_owner.get(1).unwrap().as_int(), ctx.registrar_2.id().prefix().into());
+
+    // Assert: domain_to_account = 0 (cleared by transfer)
+    let domain_to_account = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    assert_eq!(domain_to_account.get(0).unwrap().as_int(), 0);
+    assert_eq!(domain_to_account.get(1).unwrap().as_int(), 0);
+
+    // Assert: account_to_domain[registrar_1] = 0 (cleared)
+    let r1_to_domain = ctx.naming.storage().get_map_item(
+        &slot_name("naming::account_to_domain"),
+        Word::new([Felt::new(ctx.registrar_1.id().suffix().as_int()), Felt::new(ctx.registrar_1.id().prefix().into()), Felt::new(0), Felt::new(0)]),
+    )?;
+    assert_eq!(r1_to_domain.get(0).unwrap().as_int(), 0);
+    assert_eq!(r1_to_domain.get(1).unwrap().as_int(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transfer_domain_then_reactivate_by_new_owner() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    let domain = encode_domain_as_felts("test".to_string());
+    let domain_word = encode_domain("test".to_string());
+
+    // Register "test" as registrar_1
+    let register_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0),
+        Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let cost = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(), register_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    // Transfer "test" from registrar_1 to registrar_2
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_2.id().suffix().as_int()),
+        Felt::new(ctx.registrar_2.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    // Activate domain as new owner (registrar_2)
+    let activate_note = create_note_for_naming(
+        "activate_domain".to_string(),
+        NoteInputs::new(domain_word.to_vec())?,
+        ctx.registrar_2.id(), ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, activate_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
+    execute_note(&mut chain, activate_note.id(), &mut ctx.naming).await?;
+
+    // Assert: domain_to_owner = registrar_2
+    let domain_owner = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
+    assert_eq!(domain_owner.get(0).unwrap().as_int(), ctx.registrar_2.id().suffix().as_int());
+    assert_eq!(domain_owner.get(1).unwrap().as_int(), ctx.registrar_2.id().prefix().into());
+
+    // Assert: domain_to_account = registrar_2
+    let domain_to_account = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    assert_eq!(domain_to_account.get(0).unwrap().as_int(), ctx.registrar_2.id().suffix().as_int());
+    assert_eq!(domain_to_account.get(1).unwrap().as_int(), ctx.registrar_2.id().prefix().into());
+
+    // Assert: account_to_domain[registrar_2] = domain_word
+    let r2_to_domain = ctx.naming.storage().get_map_item(
+        &slot_name("naming::account_to_domain"),
+        Word::new([Felt::new(ctx.registrar_2.id().suffix().as_int()), Felt::new(ctx.registrar_2.id().prefix().into()), Felt::new(0), Felt::new(0)]),
+    )?;
+    assert_eq!(r2_to_domain, domain_word);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transfer_domain_by_non_owner_fails() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    let domain = encode_domain_as_felts("test".to_string());
+    let domain_word = encode_domain("test".to_string());
+
+    // Register "test" as registrar_1
+    let register_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0),
+        Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let cost = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(), register_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    // registrar_2 tries to transfer "test" (not the owner)
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_3.id().suffix().as_int()),
+        Felt::new(ctx.registrar_3.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer_inputs, ctx.registrar_2.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()],
+        &mut ctx.naming,
+    ).await?;
+
+    let result = execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await;
+    assert!(result.is_err(), "Expected transfer by non-owner to fail, but it succeeded");
+
+    // Owner is still registrar_1
+    let domain_owner = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
+    assert_eq!(domain_owner.get(0).unwrap().as_int(), ctx.registrar_1.id().suffix().as_int());
+    assert_eq!(domain_owner.get(1).unwrap().as_int(), ctx.registrar_1.id().prefix().into());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transfer_nonexistent_domain_fails() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    let domain = encode_domain_as_felts("ghost".to_string());
+
+    // Try to transfer unregistered domain
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_2.id().suffix().as_int()),
+        Felt::new(ctx.registrar_2.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id()],
+        &mut ctx.naming,
+    ).await?;
+
+    let result = execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await;
+    assert!(result.is_err(), "Expected transfer of nonexistent domain to fail, but it succeeded");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transfer_domain_preserves_other_domains() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    let alpha = encode_domain_as_felts("alpha".to_string());
+    let alpha_word = encode_domain("alpha".to_string());
+    let beta = encode_domain_as_felts("beta".to_string());
+    let beta_word = encode_domain("beta".to_string());
+
+    // Register "alpha" (5 letters, cost=123) as registrar_1
+    let register_alpha_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0),
+        Felt::new(0),
+        alpha[0], alpha[1], alpha[2], alpha[3],
+    ].to_vec())?;
+    let cost_alpha = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 123)?;
+    let register_alpha_note = create_note_for_naming(
+        "register_name".to_string(), register_alpha_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost_alpha.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_alpha_note.clone())?;
+
+    // Register "beta" (4 letters, cost=555) as registrar_1
+    let register_beta_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0),
+        Felt::new(0),
+        beta[0], beta[1], beta[2], beta[3],
+    ].to_vec())?;
+    let cost_beta = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register_beta_note = create_note_for_naming(
+        "register_name".to_string(), register_beta_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost_beta.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_beta_note.clone())?;
+
+    // Transfer only "alpha" to registrar_2
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_2.id().suffix().as_int()),
+        Felt::new(ctx.registrar_2.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+        alpha[0], alpha[1], alpha[2], alpha[3],
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_alpha_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, register_beta_note.id(), &mut ctx.naming).await?;
+    execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
+
+    // Assert: "alpha" owner = registrar_2
+    let alpha_owner = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_owner"), alpha_word)?;
+    assert_eq!(alpha_owner.get(0).unwrap().as_int(), ctx.registrar_2.id().suffix().as_int());
+    assert_eq!(alpha_owner.get(1).unwrap().as_int(), ctx.registrar_2.id().prefix().into());
+
+    // Assert: "beta" owner still = registrar_1
+    let beta_owner = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_owner"), beta_word)?;
+    assert_eq!(beta_owner.get(0).unwrap().as_int(), ctx.registrar_1.id().suffix().as_int());
+    assert_eq!(beta_owner.get(1).unwrap().as_int(), ctx.registrar_1.id().prefix().into());
+
+    // Assert: domain_count = 2
+    let domain_count = ctx.naming.storage().get_item(&slot_name("naming::domain_count"))?;
+    assert_eq!(domain_count.get(0).unwrap().as_int(), 2);
+
+    Ok(())
+}
+
+// ─── Registry ownership transfer tests ───────────────────────────────────────
+
+#[tokio::test]
+async fn test_transfer_ownership_happy_path() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    // Owner transfers registry ownership to registrar_1
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_1.id().suffix().as_int()),
+        Felt::new(ctx.registrar_1.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_ownership".to_string(), transfer_inputs, ctx.owner.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
+
+    // Assert: owner = registrar_1
+    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    assert_eq!(owner_slot.get(0).unwrap().as_int(), ctx.registrar_1.id().suffix().as_int());
+    assert_eq!(owner_slot.get(1).unwrap().as_int(), ctx.registrar_1.id().prefix().into());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transfer_ownership_by_non_owner_fails() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    // registrar_1 (not owner) tries to transfer ownership
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_2.id().suffix().as_int()),
+        Felt::new(ctx.registrar_2.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_ownership".to_string(), transfer_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id()],
+        &mut ctx.naming,
+    ).await?;
+
+    let result = execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await;
+    assert!(result.is_err(), "Expected ownership transfer by non-owner to fail, but it succeeded");
+
+    // Owner is still the original owner
+    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    assert_eq!(owner_slot.get(0).unwrap().as_int(), ctx.owner.id().suffix().as_int());
+    assert_eq!(owner_slot.get(1).unwrap().as_int(), ctx.owner.id().prefix().into());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_new_owner_can_set_prices_after_transfer() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    // Owner transfers registry ownership to registrar_1
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_1.id().suffix().as_int()),
+        Felt::new(ctx.registrar_1.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_ownership".to_string(), transfer_inputs, ctx.owner.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    // New owner (registrar_1) sends set_all_prices — use custom serial_num to avoid NoteId collision
+    let price_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        Felt::new(ctx.fungible_asset.faucet_id().prefix().into()),
+    ].to_vec())?;
+    let set_prices_note = create_note_for_naming_with_custom_serial_num(
+        "set_all_prices".to_string(), price_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+        Word::new([Felt::new(1), Felt::new(0), Felt::new(0), Felt::new(0)]),
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, set_prices_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
+    execute_note(&mut chain, set_prices_note.id(), &mut ctx.naming).await?;
+
+    // Assert: owner = registrar_1
+    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    assert_eq!(owner_slot.get(0).unwrap().as_int(), ctx.registrar_1.id().suffix().as_int());
+    assert_eq!(owner_slot.get(1).unwrap().as_int(), u64::from(ctx.registrar_1.id().prefix()));
+
+    // Assert: 4-letter price = 555
+    let price_slot = ctx.naming.storage().get_map_item(
+        &slot_name("naming::prices"),
+        Word::new([
+            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+            ctx.fungible_asset.faucet_id().prefix().as_felt(),
+            Felt::new(4),
+            Felt::new(0),
+        ]),
+    )?;
+    assert_eq!(price_slot.get(0).unwrap().as_int(), 555);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_old_owner_loses_admin_after_transfer() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    // Owner transfers registry ownership to registrar_1
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_1.id().suffix().as_int()),
+        Felt::new(ctx.registrar_1.id().prefix().into()),
+        Felt::new(0),
+        Felt::new(0),
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_ownership".to_string(), transfer_inputs, ctx.owner.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    // Old owner tries to set prices after transfer — use custom serial_num to avoid NoteId collision
+    let price_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        Felt::new(ctx.fungible_asset.faucet_id().prefix().into()),
+    ].to_vec())?;
+    let set_prices_note = create_note_for_naming_with_custom_serial_num(
+        "set_all_prices".to_string(), price_inputs, ctx.owner.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+        Word::new([Felt::new(2), Felt::new(0), Felt::new(0), Felt::new(0)]),
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, set_prices_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
+
+    let result = execute_note(&mut chain, set_prices_note.id(), &mut ctx.naming).await;
+    assert!(result.is_err(), "Expected old owner to lose admin after transfer, but set_prices succeeded");
+
+    // Owner is still registrar_1
+    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    assert_eq!(owner_slot.get(0).unwrap().as_int(), ctx.registrar_1.id().suffix().as_int());
+    assert_eq!(owner_slot.get(1).unwrap().as_int(), u64::from(ctx.registrar_1.id().prefix()));
+
+    Ok(())
+}
+
+// ─── Activate then transfer tests ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_activate_then_transfer_clears_activation() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    let domain = encode_domain_as_felts("test".to_string());
+    let domain_word = encode_domain("test".to_string());
+
+    // Register "test" as registrar_1
+    let register_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let cost = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(), register_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    // Activate domain as registrar_1
+    let activate_note = create_note_for_naming(
+        "activate_domain".to_string(),
+        NoteInputs::new(domain_word.to_vec())?,
+        ctx.registrar_1.id(), ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, activate_note.clone())?;
+
+    // Transfer domain to registrar_2
+    let transfer_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_2.id().suffix().as_int()),
+        Felt::new(ctx.registrar_2.id().prefix().into()),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, activate_note.id(), &mut ctx.naming).await?;
+
+    // Verify activation worked before transfer
+    let domain_to_account_before = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    assert_eq!(domain_to_account_before.get(0).unwrap().as_int(), ctx.registrar_1.id().suffix().as_int());
+
+    execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
+
+    // Assert: domain_to_owner = registrar_2
+    let domain_owner = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
+    assert_eq!(domain_owner.get(0).unwrap().as_int(), ctx.registrar_2.id().suffix().as_int());
+    assert_eq!(domain_owner.get(1).unwrap().as_int(), ctx.registrar_2.id().prefix().into());
+
+    // Assert: domain_to_account = 0 (activation cleared by transfer)
+    let domain_to_account = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    assert_eq!(domain_to_account.get(0).unwrap().as_int(), 0);
+    assert_eq!(domain_to_account.get(1).unwrap().as_int(), 0);
+
+    // Assert: account_to_domain[registrar_1] = 0 (cleared)
+    let r1_to_domain = ctx.naming.storage().get_map_item(
+        &slot_name("naming::account_to_domain"),
+        Word::new([Felt::new(ctx.registrar_1.id().suffix().as_int()), Felt::new(ctx.registrar_1.id().prefix().into()), Felt::new(0), Felt::new(0)]),
+    )?;
+    assert_eq!(r1_to_domain.get(0).unwrap().as_int(), 0);
+    assert_eq!(r1_to_domain.get(1).unwrap().as_int(), 0);
+
+    Ok(())
+}
+
+// ─── Additional domain transfer tests ────────────────────────────────────────
+
+#[tokio::test]
+async fn test_double_domain_transfer() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    let domain = encode_domain_as_felts("test".to_string());
+    let domain_word = encode_domain("test".to_string());
+
+    // Register "test" as registrar_1
+    let register_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let cost = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(), register_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    // Transfer registrar_1 → registrar_2
+    let transfer1_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_2.id().suffix().as_int()),
+        Felt::new(ctx.registrar_2.id().prefix().into()),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer1_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer1_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer1_note.clone())?;
+
+    // Transfer registrar_2 → registrar_3
+    let transfer2_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_3.id().suffix().as_int()),
+        Felt::new(ctx.registrar_3.id().prefix().into()),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer2_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer2_inputs, ctx.registrar_2.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer2_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, transfer1_note.id(), &mut ctx.naming).await?;
+    execute_note(&mut chain, transfer2_note.id(), &mut ctx.naming).await?;
+
+    // Assert: final owner = registrar_3
+    let domain_owner = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
+    assert_eq!(domain_owner.get(0).unwrap().as_int(), ctx.registrar_3.id().suffix().as_int());
+    assert_eq!(domain_owner.get(1).unwrap().as_int(), u64::from(ctx.registrar_3.id().prefix()));
+
+    // Assert: domain_to_account cleared
+    let domain_to_account = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    assert_eq!(domain_to_account.get(0).unwrap().as_int(), 0);
+    assert_eq!(domain_to_account.get(1).unwrap().as_int(), 0);
+
+    // Assert: domain_count unchanged (still 1, transfers don't add domains)
+    let domain_count = ctx.naming.storage().get_item(&slot_name("naming::domain_count"))?;
+    assert_eq!(domain_count.get(0).unwrap().as_int(), 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transfer_domain_back_to_original_owner() -> anyhow::Result<()> {
+    let mut ctx = init_naming().await?;
+
+    let domain = encode_domain_as_felts("test".to_string());
+    let domain_word = encode_domain("test".to_string());
+
+    // Register "test" as registrar_1
+    let register_inputs = NoteInputs::new([
+        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_int()),
+        ctx.fungible_asset.faucet_id().prefix().as_felt(),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let cost = FungibleAsset::new(ctx.fungible_asset.faucet_id(), 555)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(), register_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![cost.into()])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    // Transfer registrar_1 → registrar_2
+    let transfer1_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_2.id().suffix().as_int()),
+        Felt::new(ctx.registrar_2.id().prefix().into()),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer1_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer1_inputs, ctx.registrar_1.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer1_note.clone())?;
+
+    // Transfer registrar_2 → registrar_1 (back)
+    let transfer2_inputs = NoteInputs::new([
+        Felt::new(ctx.registrar_1.id().suffix().as_int()),
+        Felt::new(ctx.registrar_1.id().prefix().into()),
+        Felt::new(0), Felt::new(0),
+        domain[0], domain[1], domain[2], domain[3],
+    ].to_vec())?;
+    let transfer2_note = create_note_for_naming(
+        "transfer_domain".to_string(), transfer2_inputs, ctx.registrar_2.id(),
+        ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, transfer2_note.clone())?;
+
+    // registrar_1 re-activates domain
+    let activate_note = create_note_for_naming(
+        "activate_domain".to_string(),
+        NoteInputs::new(domain_word.to_vec())?,
+        ctx.registrar_1.id(), ctx.naming.id(), NoteAssets::new(vec![])?,
+    ).await?;
+    add_note_to_builder(&mut ctx.builder, activate_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[ctx.initialize_note.id(), ctx.set_prices_note.id(), register_note.id()],
+        &mut ctx.naming,
+    ).await?;
+    execute_note(&mut chain, transfer1_note.id(), &mut ctx.naming).await?;
+    execute_note(&mut chain, transfer2_note.id(), &mut ctx.naming).await?;
+    execute_note(&mut chain, activate_note.id(), &mut ctx.naming).await?;
+
+    // Assert: owner = registrar_1 again
+    let domain_owner = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
+    assert_eq!(domain_owner.get(0).unwrap().as_int(), ctx.registrar_1.id().suffix().as_int());
+    assert_eq!(domain_owner.get(1).unwrap().as_int(), u64::from(ctx.registrar_1.id().prefix()));
+
+    // Assert: domain_to_account = registrar_1 (re-activated)
+    let domain_to_account = ctx.naming.storage().get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    assert_eq!(domain_to_account.get(0).unwrap().as_int(), ctx.registrar_1.id().suffix().as_int());
+    assert_eq!(domain_to_account.get(1).unwrap().as_int(), u64::from(ctx.registrar_1.id().prefix()));
+
+    // Assert: account_to_domain[registrar_1] = domain_word
+    let r1_to_domain = ctx.naming.storage().get_map_item(
+        &slot_name("naming::account_to_domain"),
+        Word::new([Felt::new(ctx.registrar_1.id().suffix().as_int()), Felt::new(ctx.registrar_1.id().prefix().into()), Felt::new(0), Felt::new(0)]),
+    )?;
+    assert_eq!(r1_to_domain, domain_word);
+
+    Ok(())
+}

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -180,6 +180,20 @@ pub async fn execute_note(chain: &mut MockChain, note_id: NoteId, target: &mut A
     Ok(())
 }
 
+pub async fn execute_note_with_expected_output(chain: &mut MockChain, note_id: NoteId, target: &mut Account, expected_output_notes: Vec<OutputNote>) -> anyhow::Result<()> {
+    let tx_ctx = chain.build_tx_context(target.id(), &[note_id], &[])?
+        .extend_expected_output_notes(expected_output_notes)
+        .build()?;
+
+    let executed_tx = tx_ctx.execute().await?;
+
+    target.apply_delta(&executed_tx.account_delta())?;
+    chain.add_pending_executed_transaction(&executed_tx)?;
+    chain.prove_next_block()?;
+
+    Ok(())
+}
+
 fn create_library(account_code: String, library_path: &str) -> anyhow::Result<Library> {
     let source_manager = Arc::new(DefaultSourceManager::default());
     let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone())


### PR DESCRIPTION
Implement claim_protocol_revenue, withdraw_assets and add transfer/protocol tests
                                                                                                                                                                        

- Complete the claim_protocol_revenue and withdraw_assets contract procedures in naming.masm, 
- Add withdraw_assets note script, fix _get_asset to produce correct FungibleAsset Word format. 
- Add 12 domain/ownership transfer tests                                                                                             
- Add 5 protocol tests (double init, prices, revenue, claim, withdraw).