### PR TITLE
Migrate to Miden 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -50,28 +50,28 @@ dependencies = [
  "paste",
  "ruint",
  "rustc-hash",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -80,16 +80,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
- "syn 2.0.117",
+ "sha3 0.11.0",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "const-hex",
  "dunce",
@@ -97,15 +97,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayref"
@@ -184,9 +184,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "ascii-canvas"
@@ -205,7 +205,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -216,9 +216,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -300,15 +300,21 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -328,6 +334,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "build-rs"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -350,15 +390,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -398,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -415,7 +455,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -451,7 +491,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -461,6 +501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "codegen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573800db6c3319bc125ddbf9b9cb001ad1602957f53642ba8d09ff3ddd4da7f1"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,9 +517,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -534,6 +583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,7 +660,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
@@ -611,7 +675,41 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -645,6 +743,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,7 +803,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -683,10 +813,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -714,7 +854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -747,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -759,7 +899,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -782,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -792,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -974,7 +1114,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1008,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1061,16 +1201,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1111,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1139,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1185,14 +1323,14 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1234,10 +1372,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.9.0"
+name = "hybrid-array"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1282,7 +1429,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1313,10 +1460,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indenter"
@@ -1331,9 +1478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1374,10 +1519,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1387,13 +1533,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1408,13 +1554,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1442,6 +1587,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,7 +1610,7 @@ dependencies = [
  "petgraph 0.7.1",
  "regex",
  "regex-syntax",
- "sha3",
+ "sha3 0.10.9",
  "string_cache",
  "term",
  "unicode-xid",
@@ -1478,16 +1633,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1523,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -1533,7 +1682,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
 ]
 
 [[package]]
@@ -1549,7 +1707,21 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1558,7 +1730,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
- "logos-codegen",
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
 ]
 
 [[package]]
@@ -1576,13 +1757,13 @@ dependencies = [
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1596,49 +1777,64 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "miden-ace-codegen"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd45076fe4fef71f0f8b30aa0f018eb39c3086eeb5f3cafc0e12d60cd28339e"
+dependencies = [
+ "miden-core",
+ "miden-crypto",
+ "thiserror",
+]
 
 [[package]]
 name = "miden-agglayer"
-version = "0.14.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4302fc29d77db3d2c6323d1b211e503aafb91db2d572ef30c68829347fe79352"
+checksum = "ead17cc16651de0fea5fc3ea67109ad449c7bb274ca8ff91c5b25e2be4a0c9f8"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
  "miden-assembly",
  "miden-core",
- "miden-core-lib",
  "miden-crypto",
  "miden-protocol",
  "miden-standards",
  "miden-utils-sync",
  "primitive-types",
  "regex",
- "thiserror 2.0.18",
+ "serde",
+ "serde_json",
+ "thiserror",
  "walkdir",
 ]
 
 [[package]]
 name = "miden-air"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15646ebc95906b2a7cb66711d1e184f53fd6edc2605730bbcf0c2a129f792cf"
+checksum = "69f1a80330b3e3d3f98e08817dc6a5e3d90d11ab5e88aa9c0dad5d3b4202598b"
 dependencies = [
+ "miden-ace-codegen",
  "miden-core",
  "miden-crypto",
+ "miden-lifted-stark",
  "miden-utils-indexing",
- "thiserror 2.0.18",
+ "proptest",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "miden-assembly"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6013b3a390e0dcb29242f4480a7727965887bbf0903466c88f362b4cb20c0e"
+checksum = "8582d184360be35eb2111a99245f556f43e1066ed09192fbcd0f218c466862a5"
 dependencies = [
  "env_logger",
  "log",
@@ -1647,15 +1843,16 @@ dependencies = [
  "miden-mast-package",
  "miden-package-registry",
  "miden-project",
+ "proptest",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996156b8f7c5fe6be17dea71089c6d7985c2dec1e3a4fec068b1dfc690e25df5"
+checksum = "ffa307bc2cbd1f0cb74ed58981823f400a433900fb8f963762331fbb8389d5dc"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -1673,24 +1870,24 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-block-prover"
-version = "0.14.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde56bcea3cebe307786a856e204d84e7987c318e5a2909bcbb655d16286ce31"
+checksum = "292ded918a0ddd056dc34db471f0bef6ac7991467d513ba505a4fcc0b1ecfac4"
 dependencies = [
  "miden-protocol",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-client"
-version = "0.14.4"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07d0abdc07189903a3c7085fb4e0f88ae2a5ace616131e35ecb2d20c032123d"
+checksum = "6eb783623b8f55d013833c4eef35190f44da3629d0d13a13693285004f8d3fe2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1699,7 +1896,7 @@ dependencies = [
  "getrandom 0.3.4",
  "gloo-timers",
  "hex",
- "miden-debug",
+ "miden-agglayer",
  "miden-node-proto-build",
  "miden-note-transport-proto-build",
  "miden-protocol",
@@ -1707,6 +1904,7 @@ dependencies = [
  "miden-standards",
  "miden-testing",
  "miden-tx",
+ "miden-tx-batch-prover",
  "miette",
  "prost",
  "prost-types",
@@ -1714,7 +1912,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tonic",
  "tonic-health",
@@ -1723,14 +1921,13 @@ dependencies = [
  "tonic-web-wasm-client",
  "tracing",
  "uuid",
- "web-sys",
 ]
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.14.4"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8e6e39389a8646996108f3b835b61180754c68bcc608b0e8ab8a129cbf6626"
+checksum = "efb7f78f6ce83e114c49c601aa563df2863ebebea471023d70c3577177356b39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1741,18 +1938,18 @@ dependencies = [
  "miden-protocol",
  "rusqlite",
  "rusqlite_migration",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "miden-core"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdec54a321cdf3d23e9ef615e91cb858038c6b4d4202507bdec048fc6d7763e4"
+checksum = "80657c32850817f5f67dcf114866495a4b055531778b7c26d0602646ce777eb8"
 dependencies = [
  "derive_more",
- "itertools",
+ "log",
  "miden-crypto",
  "miden-debug-types",
  "miden-formatting",
@@ -1764,14 +1961,14 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621e8fa911a790bcf3cd3aedce80bc10922a19d6181f08ff3ca078f955cff70b"
+checksum = "16410655f32f98537afc9ddf57b71cb6d1ca9d980da5f4eea164cafcaf891b2e"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -1781,30 +1978,32 @@ dependencies = [
  "miden-package-registry",
  "miden-processor",
  "miden-utils-sync",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-crypto"
-version = "0.23.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0a034a460e27723dcfdf25effffab84331c3b46b13e7a1bd674197cc71bfe"
+checksum = "35198bebd353cddc25ad4aafb5f4ef9e71b283d71c787b8938c575c16974135d"
 dependencies = [
  "blake3",
  "cc",
  "chacha20poly1305",
  "clap",
  "curve25519-dalek",
+ "der",
  "ed25519-dalek",
  "flume",
- "glob",
  "hkdf",
  "k256",
  "miden-crypto-derive",
  "miden-field",
+ "miden-lifted-stark",
  "miden-serde-utils",
  "num",
  "num-complex",
+ "once_cell",
  "p3-blake3",
  "p3-challenger",
  "p3-dft",
@@ -1812,7 +2011,6 @@ dependencies = [
  "p3-keccak",
  "p3-matrix",
  "p3-maybe-rayon",
- "p3-miden-lifted-stark",
  "p3-symmetric",
  "p3-util",
  "rand 0.9.4",
@@ -1822,99 +2020,27 @@ dependencies = [
  "rayon",
  "serde",
  "sha2",
- "sha3",
+ "sha3 0.10.9",
  "subtle",
- "thiserror 2.0.18",
- "winter-rand-utils",
+ "thiserror",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.23.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bf6ebde028e79bcc61a3632d2f375a5cc64caa17d014459f75015238cb1e08"
+checksum = "9068c6554db0e051f62913575de9949841a46b96ae92d4b7d28e1fed5d8f052b"
 dependencies = [
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "miden-debug"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df04a684eeb96efabc63e2800a01945f7f6e19ffd00d3b49064e85f7e1fac444"
-dependencies = [
- "clap",
- "futures",
- "glob",
- "log",
- "miden-assembly",
- "miden-assembly-syntax",
- "miden-core",
- "miden-crypto",
- "miden-debug-dap",
- "miden-debug-engine",
- "miden-debug-types",
- "miden-mast-package",
- "miden-processor",
- "miden-protocol",
- "miden-thiserror",
- "miden-tx",
- "num-traits",
- "rustc-demangle",
- "serde",
- "serde_json",
- "smallvec",
- "socket2 0.5.10",
- "tokio",
- "tokio-util",
- "toml 0.8.23",
-]
-
-[[package]]
-name = "miden-debug-dap"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cd41176322df12836bb4deecd4b619f7cf8239ed7b2c4ac1da7b2830e5199c"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "miden-debug-engine"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03dd00bd4dab99dbfdec9fd07009811a7e3b3a988e74a28c6ccb735ac34e138"
-dependencies = [
- "clap",
- "glob",
- "log",
- "miden-assembly",
- "miden-assembly-syntax",
- "miden-core",
- "miden-debug-dap",
- "miden-debug-types",
- "miden-mast-package",
- "miden-processor",
- "miden-thiserror",
- "miden-tx",
- "num-traits",
- "rustc-demangle",
- "serde",
- "serde_json",
- "smallvec",
- "socket2 0.5.10",
- "toml 0.8.23",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "miden-debug-types"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e50274d11c80b901cf6c90362de8c98c8c8ad6030c80624d683b63d899a0fb"
+checksum = "956708ccb2f643db398b4b3d4f8d0baf199b1bfb5e34c8be1cd1bc811c005e8e"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1923,27 +2049,29 @@ dependencies = [
  "miden-utils-indexing",
  "miden-utils-sync",
  "paste",
+ "proptest",
  "serde",
- "serde_spanned 1.1.1",
- "thiserror 2.0.18",
+ "serde_spanned",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-field"
-version = "0.23.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38011348f4fb4c9e5ce1f471203d024721c00e3b60a91aa91aaefe6738d8b5ea"
+checksum = "379a39db52cd932a95d4017a18b712ee53ed0f86cfedf8c63ed72d687a18a191"
 dependencies = [
  "miden-serde-utils",
  "num-bigint",
  "p3-challenger",
  "p3-field",
  "p3-goldilocks",
+ "p3-util",
  "paste",
  "rand 0.10.1",
  "serde",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1956,17 +2084,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-mast-package"
-version = "0.22.1"
+name = "miden-lifted-air"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8b2e3447fcde1f0e6b76e5219f129517639772cb02ca543177f0584e315288"
+checksum = "789e0e469d1731012d8a018057317f31580611535c20d2a47c022213228cb733"
 dependencies = [
- "derive_more",
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-lifted-stark"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f62cca91182917b22a47e150028b7c785df620a15b2974a39c64e2b1b7a889d3"
+dependencies = [
+ "miden-lifted-air",
+ "miden-stark-transcript",
+ "miden-stateful-hasher",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-goldilocks",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.1",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "miden-mast-package"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37c21836b40785ce297d363c57740d4e33edcc411f84185a524eddadd5f53c7"
+dependencies = [
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1987,9 +2150,9 @@ dependencies = [
  "serde_json",
  "spin 0.9.8",
  "strip-ansi-escapes",
- "syn 2.0.117",
+ "syn 2.0.118",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror",
  "trybuild",
  "unicode-width 0.1.14",
 ]
@@ -2002,16 +2165,17 @@ checksum = "86a905f3ea65634dd4d1041a4f0fd0a3e77aa4118341d265af1a94339182222f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.14.8"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc6d12ffab3127e7d75dada761fbd78ef9f9cdb107e33110a4c86e014781e02"
+checksum = "ef3b301741cedd6d0b532583690bc21dbf856d4e14218c591f3924bc905c660a"
 dependencies = [
  "build-rs",
+ "codegen",
  "fs-err",
  "miette",
  "protox",
@@ -2020,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec23738a2eee393524a849a8dce982ad824050cc54abde145d4fb62b92c84198"
+checksum = "7399c2999453c781601f16d82f328ecc695f9375e2415a05147449990f32f71f"
 dependencies = [
  "fs-err",
  "miette",
@@ -2032,24 +2196,25 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969ba3942052e52b3968e34dbd1c52c707e75777ee42ebdae2c8f57af56cf6cf"
+checksum = "9ece6064beb0582d1c64ba30d0c548c4b7a45f87abae6d69e22fd49c8b343258"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
  "miden-mast-package",
+ "proptest",
  "pubgrub",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-processor"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec6cecbf22bd92b73a931ee80b424e46b8b7cdf4f2f3c364c25c5c15d2840da"
+checksum = "ea972ca9e45dbf26aa396367e8508db0f7292adea6f6ddf8d39d0e334285fe2b"
 dependencies = [
  "itertools",
  "miden-air",
@@ -2059,32 +2224,32 @@ dependencies = [
  "miden-utils-indexing",
  "paste",
  "rayon",
- "thiserror 2.0.18",
- "tokio",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "miden-project"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3840520c01881534fbbceb6b3687ec1c407fbaf310a35ce415fd3510abc52fdb"
+checksum = "5320e7e5b562359bd6161ac752dfe43dd4f69bb06e87f94a21a27bb656e5a20d"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
  "miden-mast-package",
  "miden-package-registry",
+ "proptest",
  "serde",
  "serde-untagged",
- "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
 name = "miden-protocol"
-version = "0.14.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e860cc978d3467297de076e9bd22f0573b82ef73a3d223d6bb957731a45b8164"
+checksum = "66340243e37da5936cb278a8dd11037813f1dc6731c2fc866703b76ed465ebc3"
 dependencies = [
  "bech32",
  "fs-err",
@@ -2094,9 +2259,9 @@ dependencies = [
  "miden-core",
  "miden-core-lib",
  "miden-crypto",
+ "miden-crypto-derive",
  "miden-mast-package",
  "miden-processor",
- "miden-protocol-macros",
  "miden-utils-sync",
  "miden-verifier",
  "rand 0.9.4",
@@ -2105,55 +2270,41 @@ dependencies = [
  "regex",
  "semver 1.0.28",
  "serde",
- "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "thiserror",
+ "toml",
  "walkdir",
 ]
 
 [[package]]
-name = "miden-protocol-macros"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4daec4a5a6f050a670a8639e78e017ab11ef0bf2e253b012505f25e6247c13e7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "miden-prover"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb2c94e36f57684d7fa0cd382adeedc1728d502dbbe69ad1c12f4a931f45511"
+checksum = "1a91bcc00840b01126cd54e3b68ce3235def2ed48803f2eeb36a035d6951fbc1"
 dependencies = [
  "bincode",
  "miden-air",
  "miden-core",
  "miden-crypto",
- "miden-debug-types",
  "miden-processor",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.14.8"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0f6545b6b7fdfdd7d57da4b2cbe546bdfc5e177f14c3086e2761ad65afae7d"
+checksum = "f2acdb9494689feeec0f60e3b61901b5eb2362b49b993b4cbc3eb75ad83514dd"
 dependencies = [
  "build-rs",
  "fs-err",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "miden-node-proto-build",
  "miden-protocol",
  "miden-tx",
  "miette",
  "prost",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -2163,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.23.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff78082e9b4ca89863e68da01b35f8a4029ee6fd912e39fa41fde4273a7debab"
+checksum = "d78cd1d4fcad937312e544f7d53423485e453598aa4fb989d2b6374027a8c136"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -2173,32 +2324,51 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.14.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f455a087f41c30636b45ead961d1e66114d2d20661887b307cede05307eeb942"
+checksum = "c7c7146b028e637f4079b5bdefeefc54d7d6e47a805451fa0a18859d19efa2ff"
 dependencies = [
+ "bon",
  "fs-err",
  "miden-assembly",
- "miden-core",
  "miden-core-lib",
- "miden-processor",
  "miden-protocol",
  "rand 0.9.4",
  "regex",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
 ]
 
 [[package]]
-name = "miden-testing"
-version = "0.14.4"
+name = "miden-stark-transcript"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84430e84c6dee90d9bd92568be1c3082113f0b4b36f9db7933380f0295207f9"
+checksum = "05901db2e30d3954243960fe21cea7fbec39f97c27774b56fd5031c28c4881ba"
+dependencies = [
+ "p3-challenger",
+ "p3-field",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-stateful-hasher"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faeb47a90c55c5d45051d23cf691588804dd531995b4582c79108b64e445a905"
+dependencies = [
+ "p3-field",
+ "p3-symmetric",
+]
+
+[[package]]
+name = "miden-testing"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4096fc44a4c88f37405be284e25efdce194d6051e9472ae136ab9249659433c"
 dependencies = [
  "anyhow",
  "itertools",
- "miden-agglayer",
- "miden-assembly",
  "miden-block-prover",
  "miden-core-lib",
  "miden-crypto",
@@ -2209,48 +2379,28 @@ dependencies = [
  "miden-tx-batch-prover",
  "rand 0.9.4",
  "rand_chacha",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "miden-thiserror"
-version = "1.0.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183ff8de338956ecfde3a38573241eb7a6f3d44d73866c210e5629c07fa00253"
-dependencies = [
- "miden-thiserror-impl",
-]
-
-[[package]]
-name = "miden-thiserror-impl"
-version = "1.0.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee4176a0f2e7d29d2a8ee7e60b6deb14ce67a20e94c3e2c7275cdb8804e1862"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-tx"
-version = "0.14.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d788795041ce5e6f947a3256314373171e4877c11b86fafeabcec4d8b8628d9"
+checksum = "94092b45bc0abc656af25473c9807d1e6cee8e682c58d3b1186f0bd0fb6471fb"
 dependencies = [
  "miden-processor",
  "miden-protocol",
  "miden-prover",
  "miden-standards",
  "miden-verifier",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.14.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce059e2d599266b00708f6f1bff6af5cf82683e76df3ec812c2d1c72e880f943"
+checksum = "f60add2b40559352661bc86970541f88ffcf98c528f301295f9dc3bf15481b46"
 dependencies = [
  "miden-protocol",
  "miden-tx",
@@ -2258,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3846c8674ccec0c37005f99c1a599a24790ba2a5e5f4e1c7aec5f456821df835"
+checksum = "d0b1ee4662beb049a824e11bb21f95a79746c52874967983c9999f1b19a2f471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2269,33 +2419,33 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397f5d1e8679cf17cf7713ffd9654840791a6ed5818b025bbc2fbfdce846579a"
+checksum = "9fdc1cd4eda372e1c4b99b9c3677e9b1f87a4d2e362a9f4b8f904273d395efc9"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
  "miden-miette",
- "paste",
  "tracing",
 ]
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8834e76299686bcce3de1685158aa4cff49b7fa5e0e00a6cc811e8f2cf5775f"
+checksum = "c31444125649f4dad9cde647f614309b6be4f918fed276ada4eb99c01e8b9ca7"
 dependencies = [
  "miden-crypto",
+ "proptest",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9e9747e9664c1a0997bb040ae291306ea0a1c74a572141ec66cec855c1b0e8"
+checksum = "807c8ae625b7652ae7246b225c907c05da72927c31a0fd71c835c4f80931e92e"
 dependencies = [
  "lock_api",
  "loom",
@@ -2305,31 +2455,31 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.22.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4580df640d889c9f3c349cd2268968e44a99a8cf0df6c36ae5b1fb273712b00"
+checksum = "ec5556dac919a1c13edeb2bd7181fc6a4c2ce52764a3e518bcdcd9ed48e5b38e"
 dependencies = [
  "bincode",
  "miden-air",
  "miden-core",
  "miden-crypto",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb29d7c049fb69373c7e775e3d4411e63e4ee608bc43826282ba62c6ec9f891"
+checksum = "1ff0511aa2201f7098995e38a3c97a319d379c3b2d26fb83677b21b71f61a7b4"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",
  "serde",
  "serde_repr",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2381,7 +2531,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2395,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2475,7 +2625,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2543,6 +2693,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2570,9 +2724,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p3-air"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
+checksum = "c824e8d7c7ddf208b742eac8d48e0b2d52d22fa013578a7762bf6931dbab1f46"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2581,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "p3-blake3"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
+checksum = "2733229a713bd83ccf5eb749e8f8e7380c1052674394a25c0422a772204a20af"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -2592,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
+checksum = "8972ccd1d5dc90e46cdb1f2ab4ee2bae49b3917e5e98aa533f0c2b779c010445"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -2605,23 +2759,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-commit"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916ae7989d5c3b49f887f5c55b2f9826bdbb81aaebf834503c4145d8b267c829"
-dependencies = [
- "itertools",
- "p3-field",
- "p3-matrix",
- "p3-util",
- "serde",
-]
-
-[[package]]
 name = "p3-dft"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
+checksum = "17771aca44632f9cc11f2718d7ea7ec06794946c4190ef3a985bfc893f14c18a"
 dependencies = [
  "itertools",
  "p3-field",
@@ -2634,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
+checksum = "6f3eb24d0591fd4d282d89cbe4e4efba5571c699375006f80b2cbf53ce83461c"
 dependencies = [
  "itertools",
  "num-bigint",
@@ -2650,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
+checksum = "5751c6591a0d2397d726620c2c29a7436ec6c5e19d2ed74ca5d078d4fbb18eb5"
 dependencies = [
  "num-bigint",
  "p3-challenger",
@@ -2670,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
+checksum = "77a7df174ff0c19a8742eb4698eaa1667c5f858d018e2faf09c55f1f24a6f9c3"
 dependencies = [
  "p3-symmetric",
  "p3-util",
@@ -2681,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
+checksum = "ea9c94c0714944e7b8a9a62e6340b1e3e1d3f8ecfd3e35c08798360200e73eff"
 dependencies = [
  "itertools",
  "p3-field",
@@ -2696,127 +2837,31 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
+checksum = "eebc233a34b1ab0273f35b4052fa2eeb3114b22ba4575bd7da00716e878ffb77"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
+checksum = "6b5441fa8116246ec9e6c835f15273cb27777ca572960ec87476b67fef13e01e"
 dependencies = [
  "p3-dft",
  "p3-field",
  "p3-symmetric",
  "p3-util",
  "rand 0.10.1",
-]
-
-[[package]]
-name = "p3-miden-lifted-air"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
-dependencies = [
- "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-util",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "p3-miden-lifted-fri"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
-dependencies = [
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-miden-lmcs",
- "p3-miden-transcript",
- "p3-util",
- "rand 0.10.1",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "p3-miden-lifted-stark"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
-dependencies = [
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-miden-lifted-air",
- "p3-miden-lifted-fri",
- "p3-miden-lmcs",
- "p3-miden-stateful-hasher",
- "p3-miden-transcript",
- "p3-util",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "p3-miden-lmcs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
-dependencies = [
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-miden-stateful-hasher",
- "p3-miden-transcript",
- "p3-symmetric",
- "p3-util",
- "rand 0.10.1",
- "serde",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "p3-miden-stateful-hasher"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
-dependencies = [
- "p3-field",
- "p3-symmetric",
-]
-
-[[package]]
-name = "p3-miden-transcript"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
-dependencies = [
- "p3-challenger",
- "p3-field",
- "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "p3-monty-31"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
+checksum = "8724f330ea6d19dd4f2436aa0f88b5fcbf88f0f55ca7fccd3fea8b736dbcddad"
 dependencies = [
  "itertools",
  "num-bigint",
@@ -2838,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon1"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+checksum = "04e2a562fea210baae390a32f9ecf0dd8724ae3f4352d1c8e413077b6f00a162"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -2849,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
+checksum = "06394851c161d17e4aa4ad2aad5557d32f14cadd1dc838f965d8e1821a63b8c5"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -2862,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
+checksum = "9ac1a276d421f8ef3361bb7d8c39a02c93c6b3f10eeaa559cc4c50222f9a5b82"
 dependencies = [
  "itertools",
  "p3-field",
@@ -2874,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
+checksum = "d08a58162a4c264269ef454f0b28dcda89939490eecacb2b2cf5b00f719b80f6"
 dependencies = [
  "rayon",
  "serde",
@@ -2950,22 +2995,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3038,7 +3083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3081,7 +3126,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3099,7 +3144,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha",
@@ -3116,7 +3161,7 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3146,30 +3191,30 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-reflect"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
 dependencies = [
- "logos",
+ "logos 0.16.1",
  "miette",
  "prost",
  "prost-types",
@@ -3196,7 +3241,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3205,10 +3250,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
 dependencies = [
- "logos",
+ "logos 0.15.1",
  "miette",
  "prost-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3221,17 +3266,17 @@ dependencies = [
  "log",
  "priority-queue",
  "rustc-hash",
- "thiserror 2.0.18",
+ "thiserror",
  "version-ranges",
 ]
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -3247,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3381,14 +3426,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3409,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
@@ -3439,9 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "proptest",
  "rand 0.8.6",
@@ -3464,7 +3509,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3518,7 +3563,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3527,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -3542,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3554,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -3628,7 +3673,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3709,14 +3754,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3733,16 +3778,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3762,7 +3798,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3771,8 +3807,18 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -3786,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -3796,15 +3842,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3814,34 +3860,24 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3954,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3965,14 +4001,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3994,7 +4030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4041,31 +4077,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4076,7 +4092,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4099,15 +4115,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4120,7 +4136,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4160,39 +4176,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -4205,33 +4199,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -4241,9 +4215,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64",
@@ -4258,7 +4232,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.3",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4271,21 +4245,21 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
 dependencies = [
  "prost",
  "tokio",
@@ -4296,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -4307,16 +4281,16 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
  "tonic-build",
 ]
@@ -4337,7 +4311,7 @@ dependencies = [
  "httparse",
  "js-sys",
  "pin-project",
- "thiserror 2.0.18",
+ "thiserror",
  "tonic",
  "tower-service",
  "wasm-bindgen",
@@ -4396,7 +4370,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4456,9 +4430,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
 dependencies = [
  "dissimilar",
  "glob",
@@ -4467,7 +4441,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -4478,9 +4452,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uint"
@@ -4520,9 +4494,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4548,7 +4522,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -4566,11 +4540,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4639,27 +4613,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4670,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4680,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4690,46 +4655,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -4746,22 +4689,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver 1.0.28",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4797,7 +4728,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4808,7 +4739,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4919,128 +4850,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-
-[[package]]
-name = "winter-rand-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ff3b651754a7bd216f959764d0a5ab6f4b551c9a3a08fb9ccecbed594b614a"
-dependencies = [
- "rand 0.9.4",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "x25519-dalek"
@@ -5054,29 +4872,29 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,18 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-miden-client = { version = "0.14.4", features = ["testing", "tonic"] }
-miden-standards = { version = "0.14.4", default-features = false }
-miden-protocol = { version = "0.14.4", default-features = false, features = ["testing"] }
-miden-crypto = { version = "0.23.0", features = ["executable"] }
-miden-assembly = "0.22.1"
-miden-testing = "0.14.4"
+miden-client = { version = "0.15", features = ["testing", "tonic"] }
+miden-standards = { version = "0.15.3", default-features = false }
+miden-protocol = { version = "0.15.3", default-features = false, features = ["testing"] }
+miden-crypto = { version = "0.25.0", features = ["executable"] }
+miden-assembly = "0.23"
+miden-testing = "0.15"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
 rand_chacha = "0.9.0"
-miden-client-sqlite-store = "0.14.4"
+miden-client-sqlite-store = "0.15"
 chrono = "0.4"
 anyhow = "1"
 dotenvy = "0.15"

--- a/masm/accounts/naming.masm
+++ b/masm/accounts/naming.masm
@@ -5,6 +5,7 @@ use miden::protocol::input_note
 use miden::protocol::output_note
 use miden::protocol::active_note
 use miden::protocol::tx
+use miden::protocol::asset
 use miden::standards::wallets::basic->basic_wallet
 
 # Storage Slots
@@ -204,9 +205,15 @@ pub proc claim_protocol_revenue
     exec._get_remaining_revenue
     # [claimable_revenue, note_idx]
     exec._get_asset
-    # [ASSET, note_idx]
+    # [ASSET_KEY, ASSET_VALUE, note_idx]
+    # 0.15: remove_asset and output_note::add_asset each consume the full (KEY, VALUE)
+    # pair, so duplicate it before removing from the vault.
+    dupw.1 dupw.1
+    # [ASSET_KEY, ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx]
     exec.native_account::remove_asset
-    # [ASSET, note_idx]
+    # [REMAINING_ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx]
+    dropw
+    # [ASSET_KEY, ASSET_VALUE, note_idx]
     exec.output_note::add_asset
     # []
     exec._set_claimed_to_total
@@ -228,9 +235,14 @@ pub proc withdraw_assets
     exec._get_balance
     # [balance, note_idx]
     exec._get_asset
-    # [ASSET, note_idx]
+    # [ASSET_KEY, ASSET_VALUE, note_idx]
+    # 0.15: duplicate the (KEY, VALUE) pair so it survives remove_asset for the output note.
+    dupw.1 dupw.1
+    # [ASSET_KEY, ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx]
     exec.native_account::remove_asset
-    # [ASSET, note_idx]
+    # [REMAINING_ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx]
+    dropw
+    # [ASSET_KEY, ASSET_VALUE, note_idx]
     exec.output_note::add_asset
     # []
 end
@@ -295,13 +307,16 @@ proc _set_claimed_to_total
 end
 
 # Input: [amt] Memory [PAYMENT_TOKEN]
-# Output: [ASSET] where ASSET = [prefix, suffix, 0, amt] on stack
-# Word format: [amt, 0, suffix, prefix] matching FungibleAsset encoding
+# Output: [ASSET_KEY, ASSET_VALUE]
+# 0.15: a fungible asset is an 8-felt (ASSET_KEY, ASSET_VALUE) pair built via the
+# asset helper, which encodes the composition metadata into the key.
 proc _get_asset
     padw mem_loadw_be.MEM_PAYMENT_TOKEN drop drop
     # [prefix, suffix, amt]
-    push.0 movdn.2
-    # [prefix, suffix, 0, amt]
+    swap push.0
+    # [enable_callbacks=0, suffix, prefix, amt]
+    exec.asset::create_fungible_asset
+    # [ASSET_KEY, ASSET_VALUE]
 end
 
 # Input: [account_prefix, account_suffix] Memory [DOMAIN]
@@ -384,6 +399,12 @@ end
 proc _get_balance
     padw mem_loadw_be.MEM_PAYMENT_TOKEN drop drop swap
     # [suffix, prefix]
+    # 0.15: get_balance takes a full ASSET_KEY; build the fungible vault key
+    # (callbacks disabled) from the faucet id.
+    push.0
+    # [enable_callbacks=0, suffix, prefix]
+    exec.asset::create_fungible_key
+    # [ASSET_KEY]
     exec.active_account::get_balance
     # [balance]
 end

--- a/masm/accounts/naming_unsafe.masm
+++ b/masm/accounts/naming_unsafe.masm
@@ -5,6 +5,7 @@ use miden::protocol::input_note
 use miden::protocol::output_note
 use miden::protocol::active_note
 use miden::protocol::tx
+use miden::protocol::asset
 use miden::standards::wallets::basic->basic_wallet
 
 # Storage Slots
@@ -348,6 +349,12 @@ end
 proc _get_balance
     padw mem_loadw_be.MEM_PAYMENT_TOKEN drop drop swap
     # [suffix, prefix]
+    # 0.15: get_balance takes a full ASSET_KEY; build the fungible vault key
+    # (callbacks disabled) from the faucet id.
+    push.0
+    # [enable_callbacks=0, suffix, prefix]
+    exec.asset::create_fungible_key
+    # [ASSET_KEY]
     exec.active_account::get_balance
     # [balance]
 end

--- a/masm/notes/P2N.masm
+++ b/masm/notes/P2N.masm
@@ -33,7 +33,8 @@ const ERR_P2N_TARGET_NAME_MISMATCH="P2N's target name address and resolved addre
 #! - The same non-fungible asset already exists in the account.
 #! - Adding a fungible asset would result in amount overflow, i.e., the total amount would be
 #!   greater than 2^63.
-begin
+@note_script
+pub proc main
     # store the note inputs to memory starting at address 0
     padw push.0 exec.active_note::get_storage
     # => [num_inputs, inputs_ptr, EMPTY_WORD]

--- a/masm/notes/activate_domain.masm
+++ b/masm/notes/activate_domain.masm
@@ -5,10 +5,11 @@ use miden::core::sys
 const DOMAIN=0
 
 # Input (arguments): [DOMAIN]
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    drop drop
+    drop
     mem_loadw_be.DOMAIN
     # [DOMAIN]
     call.naming::activate_domain

--- a/masm/notes/claim_protocol_revenue.masm
+++ b/masm/notes/claim_protocol_revenue.masm
@@ -6,9 +6,10 @@ const RECIPIENT=0
 const NOTE_DETAILS=4
 const TOKEN=8
 
-begin
+@note_script
+pub proc main
     push.0
-    exec.active_note::get_storage drop drop
+    exec.active_note::get_storage drop
 
     mem_loadw_be.RECIPIENT padw mem_loadw_be.NOTE_DETAILS padw mem_loadw_be.TOKEN
     # [TOKEN, DETAILS, RECIPIENT]

--- a/masm/notes/clear_expired_domain.masm
+++ b/masm/notes/clear_expired_domain.masm
@@ -5,10 +5,11 @@ use miden::core::sys
 const DOMAIN=0
 
 # Input (arguments): [DOMAIN]
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    drop drop
+    drop
     mem_loadw_be.DOMAIN
     # [DOMAIN]
     call.naming::clear_expired_domain

--- a/masm/notes/extend_domain.masm
+++ b/masm/notes/extend_domain.masm
@@ -6,10 +6,11 @@ const TOKEN_PTR=0
 const DOMAIN_PTR=4
 const REG_LEN_PTR=8
 # Input (arguments): [TOKEN, DOMAIN, REG_LEN]
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    drop drop
+    drop
     padw mem_loadw_be.REG_LEN_PTR padw mem_loadw_be.DOMAIN_PTR padw mem_loadw_be.TOKEN_PTR
     # [TOKEN, DOMAIN, REG_LEN]
     call.naming::extend_domain

--- a/masm/notes/initialize_naming.masm
+++ b/masm/notes/initialize_naming.masm
@@ -6,11 +6,12 @@ const INITIALIZE_NOTE_INPUT_PTR=0
 const TIMESTAMP_INPUT_PTR=4
 
 # Input (arguments): [OWNER, TS]
-begin
+@note_script
+pub proc main
     push.INITIALIZE_NOTE_INPUT_PTR
     exec.active_note::get_storage
-    # [num_inputs, init_ptr]
-    drop drop padw mem_loadw_be.TIMESTAMP_INPUT_PTR
+    # [num_storage_items]
+    drop padw mem_loadw_be.TIMESTAMP_INPUT_PTR
     padw mem_loadw_be.INITIALIZE_NOTE_INPUT_PTR
     # [INPUTS]
     call.naming::init

--- a/masm/notes/register_name.masm
+++ b/masm/notes/register_name.masm
@@ -6,10 +6,11 @@ const TOKEN_PTR=0
 const DOMAIN_PTR=4
 const REG_LEN_PTR=8
 # Input (arguments): [TOKEN, DOMAIN, REG_LEN]
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    drop drop
+    drop
     padw mem_loadw_be.REG_LEN_PTR padw mem_loadw_be.DOMAIN_PTR padw mem_loadw_be.TOKEN_PTR
     # [TOKEN, DOMAIN, REG_LEN]
     call.naming::register

--- a/masm/notes/register_with_referrer.masm
+++ b/masm/notes/register_with_referrer.masm
@@ -7,10 +7,11 @@ const TOKEN_PTR=4
 const DOMAIN_PTR=8
 const REG_LEN_PTR=12
 # Input (arguments): [REFERRER, TOKEN, DOMAIN, REG_LEN]
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    drop drop
+    drop
     padw mem_loadw_be.REG_LEN_PTR padw mem_loadw_be.DOMAIN_PTR padw mem_loadw_be.TOKEN_PTR padw mem_loadw_be.REFERRER_PTR
     # [REFERRER ,TOKEN, DOMAIN, REG_LEN]
     call.naming::register_with_referrer

--- a/masm/notes/set_all_prices.masm
+++ b/masm/notes/set_all_prices.masm
@@ -9,11 +9,12 @@ const THREE_LETTER_PRICE=789
 const FOUR_LETTER_PRICE=555
 const FIVE_LETTER_PRICE=123
 
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    # [num_inputs, init_ptr]
-    drop drop
+    # [num_storage_items]
+    drop
     # SET 1 LETTER
     mem_loadw_be.0 drop drop
     # [token_prefix, token_suffix]

--- a/masm/notes/set_all_prices_testnet.masm
+++ b/masm/notes/set_all_prices_testnet.masm
@@ -9,11 +9,12 @@ const THREE_LETTER_PRICE=120000000
 const FOUR_LETTER_PRICE=55000000
 const FIVE_LETTER_PRICE=20000000
 
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    # [num_inputs, init_ptr]
-    drop drop
+    # [num_storage_items]
+    drop
     # SET 1 LETTER
     mem_loadw_be.0 drop drop
     # [token_prefix, token_suffix]

--- a/masm/notes/set_referrer_rate.masm
+++ b/masm/notes/set_referrer_rate.masm
@@ -6,11 +6,12 @@ const RATE_PTR=0
 const REFERRER_PTR=4
 
 # Input (arguments): [RATE, REFERRER]
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    # [num_inputs, init_ptr]
-    drop drop padw mem_loadw_be.RATE_PTR
+    # [num_storage_items]
+    drop padw mem_loadw_be.RATE_PTR
     padw mem_loadw_be.REFERRER_PTR
     # [REFERRER, RATE]
     call.naming::set_referrer_rate

--- a/masm/notes/transfer_domain.masm
+++ b/masm/notes/transfer_domain.masm
@@ -6,10 +6,11 @@ const NEW_OWNER_PTR=0
 const DOMAIN_PTR=4
 
 # Input (arguments): [NEW_OWNER, DOMAIN]
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    drop drop
+    drop
     mem_loadw_be.DOMAIN_PTR padw mem_loadw_be.NEW_OWNER_PTR
     # [NEW_OWNER, DOMAIN]
     call.naming::transfer

--- a/masm/notes/transfer_ownership.masm
+++ b/masm/notes/transfer_ownership.masm
@@ -5,10 +5,11 @@ use miden::core::sys
 const NEW_OWNER_PTR=0
 
 # Input (arguments): [NEW_OWNER]
-begin
+@note_script
+pub proc main
     push.0
     exec.active_note::get_storage
-    drop drop
+    drop
     mem_loadw_be.NEW_OWNER_PTR
     # [NEW_OWNER]
     call.naming::update_registry_owner

--- a/masm/notes/withdraw_assets.masm
+++ b/masm/notes/withdraw_assets.masm
@@ -6,9 +6,10 @@ const RECIPIENT=0
 const NOTE_DETAILS=4
 const TOKEN=8
 
-begin
+@note_script
+pub proc main
     push.0
-    exec.active_note::get_storage drop drop
+    exec.active_note::get_storage drop
 
     mem_loadw_be.RECIPIENT padw mem_loadw_be.NOTE_DETAILS padw mem_loadw_be.TOKEN
     # [TOKEN, DETAILS, RECIPIENT]

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,6 +1,6 @@
 use miden_client::{
     Client,
-    account::{Account, AccountBuilder, AccountId, AccountStorageMode, AccountType},
+    account::{Account, AccountBuilder, AccountId, AccountType},
     auth::{AuthScheme, AuthSecretKey, NoAuth},
     keystore::{FilesystemKeyStore, Keystore},
 };
@@ -25,8 +25,8 @@ pub async fn create_deployer_account(
 
     // Build the account
     let deployer_account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::RegularAccountUpdatableCode)
-        .storage_mode(AccountStorageMode::Public)
+        // 0.15: storage mode is merged into AccountType (Public = on-chain state).
+        .account_type(AccountType::Public)
         .with_auth_component(AuthSingleSig::new(
             key_pair.public_key().to_commitment(),
             AuthScheme::Falcon512Poseidon2,
@@ -54,11 +54,11 @@ pub async fn create_naming_account(
 ) -> anyhow::Result<Account> {
     let account_code = fs::read_to_string(Path::new("./masm/accounts/naming_unsafe.masm")).unwrap();
 
-    let storage_mode = if is_network {
-        AccountStorageMode::Network
-    } else {
-        AccountStorageMode::Public
-    };
+    // 0.15: AccountStorageMode (incl. Network) is gone; storage mode is folded into
+    // AccountType. Both network and non-network deployments use on-chain (Public) state.
+    // NOTE: the dedicated network-account auth (NetworkAccountNoteAllowlist) component is a
+    // separate migration step; `is_network` is retained for note-targeting/consumption logic.
+    let _ = is_network;
 
     // Compile the account code using the assembler
     let source_manager = Arc::new(miden_assembly::DefaultSourceManager::default());
@@ -73,15 +73,14 @@ pub async fn create_naming_account(
     let account_component = AccountComponent::new(
         (*library).clone(),
         naming_storage(),
-        AccountComponentMetadata::new("midenid-naming", [AccountType::RegularAccountImmutableCode]),
+        AccountComponentMetadata::new("midenid-naming"),
     )?;
 
     let mut seed = [0_u8; 32];
     client.rng().fill_bytes(&mut seed);
 
     let account = AccountBuilder::new(seed)
-        .account_type(AccountType::RegularAccountImmutableCode)
-        .storage_mode(storage_mode)
+        .account_type(AccountType::Public)
         .with_auth_component(NoAuth)
         .with_component(account_component.clone())
         .build()?;

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -8,11 +8,32 @@ use miden_protocol::{
     account::{AccountComponent, AccountComponentMetadata},
     transaction::TransactionKernel,
 };
-use miden_standards::{account::auth::AuthSingleSig, account::wallets::BasicWallet};
+use miden_standards::{
+    account::auth::{AuthNetworkAccount, AuthSingleSig},
+    account::wallets::BasicWallet,
+};
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use std::{collections::BTreeSet, fs, path::Path, sync::Arc};
 
+use crate::notes::{
+    compile_init_on_chain_tx_script, compile_naming_note_script, naming_masm_path,
+};
 use crate::storage::naming_storage;
+
+/// Note scripts a deployed network naming account is allowed to auto-consume. Only notes whose
+/// `call.naming::*` target exists in `naming.masm` are included (excludes the referral notes and
+/// extend/clear notes, whose procedures live in `naming_discount.masm`).
+const NETWORK_ALLOWED_NOTES: &[&str] = &[
+    "initialize_naming",
+    "set_all_prices",
+    "set_all_prices_testnet",
+    "register_name",
+    "activate_domain",
+    "transfer_domain",
+    "transfer_ownership",
+    "claim_protocol_revenue",
+    "withdraw_assets",
+];
 
 pub async fn create_deployer_account(
     client: &mut Client<FilesystemKeyStore>,
@@ -52,13 +73,7 @@ pub async fn create_naming_account(
     client: &mut Client<FilesystemKeyStore>,
     is_network: bool,
 ) -> anyhow::Result<Account> {
-    let account_code = fs::read_to_string(Path::new("./masm/accounts/naming_unsafe.masm")).unwrap();
-
-    // 0.15: AccountStorageMode (incl. Network) is gone; storage mode is folded into
-    // AccountType. Both network and non-network deployments use on-chain (Public) state.
-    // NOTE: the dedicated network-account auth (NetworkAccountNoteAllowlist) component is a
-    // separate migration step; `is_network` is retained for note-targeting/consumption logic.
-    let _ = is_network;
+    let account_code = fs::read_to_string(Path::new(naming_masm_path(is_network))).unwrap();
 
     // Compile the account code using the assembler
     let source_manager = Arc::new(miden_assembly::DefaultSourceManager::default());
@@ -79,9 +94,28 @@ pub async fn create_naming_account(
     let mut seed = [0_u8; 32];
     client.rng().fill_bytes(&mut seed);
 
+    // 0.15: a network account is defined by the standardized NetworkAccountNoteAllowlist slot,
+    // provided by the AuthNetworkAccount auth component. It pins the set of note-script roots the
+    // network may auto-consume against this account. Non-network deployments use NoAuth.
+    let auth_component: AccountComponent = if is_network {
+        let mut allowed_roots = BTreeSet::new();
+        for name in NETWORK_ALLOWED_NOTES {
+            allowed_roots.insert(compile_naming_note_script(name, is_network)?.root());
+        }
+        // The deploy's init_on_chain self-transaction must also be allowlisted, otherwise the
+        // network account rejects it (empty tx-script allowlist blocks all tx scripts).
+        let mut allowed_tx_scripts = BTreeSet::new();
+        allowed_tx_scripts.insert(compile_init_on_chain_tx_script(is_network)?.root());
+        AuthNetworkAccount::with_allowed_notes(allowed_roots)?
+            .with_allowed_tx_scripts(allowed_tx_scripts)
+            .into()
+    } else {
+        NoAuth.into()
+    };
+
     let account = AccountBuilder::new(seed)
         .account_type(AccountType::Public)
-        .with_auth_component(NoAuth)
+        .with_auth_component(auth_component)
         .with_component(account_component.clone())
         .build()?;
 

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -4,20 +4,15 @@ use miden_client::{
     auth::{AuthScheme, AuthSecretKey, NoAuth},
     keystore::{FilesystemKeyStore, Keystore},
 };
-use miden_protocol::{
-    account::{AccountComponent, AccountComponentMetadata},
-    transaction::TransactionKernel,
-};
+use miden_protocol::account::{AccountComponent, AccountComponentMetadata};
 use miden_standards::{
     account::auth::{AuthNetworkAccount, AuthSingleSig},
     account::wallets::BasicWallet,
 };
 use rand::RngCore;
-use std::{collections::BTreeSet, fs, path::Path, sync::Arc};
+use std::{collections::BTreeSet, sync::Arc};
 
-use crate::notes::{
-    compile_init_on_chain_tx_script, compile_naming_note_script, naming_masm_path,
-};
+use crate::notes::{compile_init_on_chain_tx_script, compile_note_script_with_lib, naming_library};
 use crate::storage::naming_storage;
 
 /// Note scripts a deployed network naming account is allowed to auto-consume. Only notes whose
@@ -73,20 +68,12 @@ pub async fn create_naming_account(
     client: &mut Client<FilesystemKeyStore>,
     is_network: bool,
 ) -> anyhow::Result<Account> {
-    let account_code = fs::read_to_string(Path::new(naming_masm_path(is_network))).unwrap();
-
-    // Compile the account code using the assembler
-    let source_manager = Arc::new(miden_assembly::DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone())
-        .with_dynamic_library(miden_standards::StandardsLib::default())
-        .expect("failed to load standards lib");
-    let module = miden_assembly::ast::Module::parser(miden_assembly::ast::ModuleKind::Library)
-        .parse_str("naming", account_code, source_manager)
-        .unwrap();
-    let library = assembler.clone().assemble_library([module]).unwrap();
+    // Assemble the naming contract once and reuse it for the account component and every
+    // allowlisted note-script root.
+    let library = naming_library(is_network)?;
 
     let account_component = AccountComponent::new(
-        (*library).clone(),
+        library.clone(),
         naming_storage(),
         AccountComponentMetadata::new("midenid-naming"),
     )?;
@@ -100,7 +87,7 @@ pub async fn create_naming_account(
     let auth_component: AccountComponent = if is_network {
         let mut allowed_roots = BTreeSet::new();
         for name in NETWORK_ALLOWED_NOTES {
-            allowed_roots.insert(compile_naming_note_script(name, is_network)?.root());
+            allowed_roots.insert(compile_note_script_with_lib(name, &library)?.root());
         }
         // The deploy's init_on_chain self-transaction must also be allowlisted, otherwise the
         // network account rejects it (empty tx-script allowlist blocks all tx scripts).

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -129,10 +129,11 @@ pub fn encode_domain(domain: String) -> Word {
     // Format: [felt1, felt2, felt3, length]
     // This is reversed for MASM storage (becomes [length, felt3, felt2, felt1] on stack)
     Word::new([
-        Felt::new(felt1),
-        Felt::new(felt2),
-        Felt::new(felt3),
-        Felt::new(len as u64),
+        // 0.15: Felt::new is fallible; packed values are < field modulus so unwrap is safe.
+        Felt::new(felt1).unwrap(),
+        Felt::new(felt2).unwrap(),
+        Felt::new(felt3).unwrap(),
+        Felt::new(len as u64).unwrap(),
     ])
 }
 
@@ -195,10 +196,11 @@ pub fn unsafe_encode_domain(domain: String) -> Word {
     // Format: [felt1, felt2, felt3, length]
     // This is reversed for MASM storage (becomes [length, felt3, felt2, felt1] on stack)
     Word::new([
-        Felt::new(felt1),
-        Felt::new(felt2),
-        Felt::new(felt3),
-        Felt::new(len as u64),
+        // 0.15: Felt::new is fallible; packed values are < field modulus so unwrap is safe.
+        Felt::new(felt1).unwrap(),
+        Felt::new(felt2).unwrap(),
+        Felt::new(felt3).unwrap(),
+        Felt::new(len as u64).unwrap(),
     ])
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ enum Commands {
         /// Name to register
         #[arg(long)]
         name: String,
+
+        /// Target naming account is a network account (skips manual note consumption)
+        #[arg(long)]
+        as_network: bool,
     },
 
     /// Consume Note
@@ -93,6 +97,7 @@ async fn main() -> anyhow::Result<()> {
             account,
             naming_account,
             faucet_id,
+            as_network,
         } => {
             println!("\n");
             println!("=================================================");
@@ -100,7 +105,8 @@ async fn main() -> anyhow::Result<()> {
             println!(
                 "Entered account needs to be funded and added to keystore to send the registration note."
             );
-            send_register_note(account, naming_account, faucet_id, name, cli.testnet).await?;
+            send_register_note(account, naming_account, faucet_id, name, as_network, cli.testnet)
+                .await?;
         }
         Commands::ConsumeNote {
             note_id,

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -7,8 +7,8 @@ use miden_client::{
     account::AccountId,
     keystore::FilesystemKeyStore,
     note::{
-        Note, NoteAssets, NoteAttachments, NoteRecipient, NoteStorage, NoteTag, NoteType,
-        PartialNoteMetadata,
+        Note, NoteAssets, NoteAttachments, NoteRecipient, NoteScript, NoteStorage, NoteTag,
+        NoteType, PartialNoteMetadata,
     },
 };
 use miden_crypto::{Felt, Word};
@@ -17,6 +17,42 @@ use miden_standards::code_builder::CodeBuilder;
 use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint};
 use rand::{Rng, RngCore};
 use std::{fs, path::Path, sync::Arc};
+
+/// The naming contract MASM the notes/account link against. Network deployments use the full
+/// `naming.masm`; the (non-network) devnet/testnet path uses `naming_unsafe.masm`.
+pub fn naming_masm_path(is_network: bool) -> &'static str {
+    if is_network {
+        "./masm/accounts/naming.masm"
+    } else {
+        "./masm/accounts/naming_unsafe.masm"
+    }
+}
+
+/// Compiles a note script (linking the naming contract library) so its script root can be read.
+/// Used to build the network account's note-script allowlist.
+pub fn compile_naming_note_script(name: &str, is_network: bool) -> anyhow::Result<NoteScript> {
+    let note_code = fs::read_to_string(Path::new(&format!("./masm/notes/{}.masm", name)))?;
+    let naming_code = fs::read_to_string(Path::new(naming_masm_path(is_network)))?;
+    let library = create_library(naming_code, "miden_name::naming")?;
+    let note_script = CodeBuilder::default()
+        .with_dynamically_linked_library(&library)?
+        .compile_note_script(note_code)?;
+    Ok(note_script)
+}
+
+/// Compiles the `init_on_chain` transaction script (linking the naming library). Shared by the
+/// deploy flow and the network account's tx-script allowlist so the roots match.
+pub fn compile_init_on_chain_tx_script(
+    is_network: bool,
+) -> anyhow::Result<miden_client::transaction::TransactionScript> {
+    let script_code = fs::read_to_string(Path::new("./masm/scripts/init_on_chain.masm"))?;
+    let naming_code = fs::read_to_string(Path::new(naming_masm_path(is_network)))?;
+    let library = create_library(naming_code, "miden_name::naming")?;
+    let tx_script = CodeBuilder::default()
+        .with_dynamically_linked_library(&library)?
+        .compile_tx_script(script_code)?;
+    Ok(tx_script)
+}
 
 pub async fn create_note_for_naming_with_client(
     name: String,
@@ -28,7 +64,7 @@ pub async fn create_note_for_naming_with_client(
     client: &mut Client<FilesystemKeyStore>,
 ) -> anyhow::Result<Note> {
     let note_code = fs::read_to_string(Path::new(&format!("./masm/notes/{}.masm", name)))?;
-    let naming_code = fs::read_to_string(Path::new("./masm/accounts/naming_unsafe.masm")).unwrap();
+    let naming_code = fs::read_to_string(Path::new(naming_masm_path(is_network))).unwrap();
     let library = create_library(naming_code, "miden_name::naming")?;
 
     let serial_num = Word::new([

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -6,7 +6,10 @@ use miden_client::{
     Client,
     account::AccountId,
     keystore::FilesystemKeyStore,
-    note::{Note, NoteAssets, NoteMetadata, NoteRecipient, NoteStorage, NoteTag, NoteType},
+    note::{
+        Note, NoteAssets, NoteAttachments, NoteRecipient, NoteStorage, NoteTag, NoteType,
+        PartialNoteMetadata,
+    },
 };
 use miden_crypto::{Felt, Word};
 use miden_protocol::transaction::TransactionKernel;
@@ -21,6 +24,7 @@ pub async fn create_note_for_naming_with_client(
     sender: AccountId,
     target_id: AccountId,
     assets: NoteAssets,
+    is_network: bool,
     client: &mut Client<FilesystemKeyStore>,
 ) -> anyhow::Result<Note> {
     let note_code = fs::read_to_string(Path::new(&format!("./masm/notes/{}.masm", name)))?;
@@ -28,10 +32,10 @@ pub async fn create_note_for_naming_with_client(
     let library = create_library(naming_code, "miden_name::naming")?;
 
     let serial_num = Word::new([
-        Felt::new(client.rng().next_u64()),
-        Felt::new(client.rng().next_u64()),
-        Felt::new(client.rng().next_u64()),
-        Felt::new(client.rng().next_u64()),
+        Felt::new(client.rng().next_u64())?,
+        Felt::new(client.rng().next_u64())?,
+        Felt::new(client.rng().next_u64())?,
+        Felt::new(client.rng().next_u64())?,
     ]);
 
     let note_script = CodeBuilder::default()
@@ -40,12 +44,16 @@ pub async fn create_note_for_naming_with_client(
 
     let recipient = NoteRecipient::new(serial_num, note_script, inputs.clone());
     let tag = NoteTag::with_account_target(target_id);
-    let mut metadata = NoteMetadata::new(sender, NoteType::Public).with_tag(tag);
-    if target_id.is_network() {
+    // 0.15: metadata is built from PartialNoteMetadata; attachments (e.g. the network-account
+    // target) are now passed to the Note constructor instead of `NoteMetadata::with_attachment`.
+    let partial = PartialNoteMetadata::new(sender, NoteType::Public).with_tag(tag);
+    let note = if is_network {
         let network_target = NetworkAccountTarget::new(target_id, NoteExecutionHint::Always)?;
-        metadata = metadata.with_attachment(network_target.into());
-    }
-    let note = Note::new(assets, metadata, recipient);
+        let attachments = NoteAttachments::new(vec![network_target.into()])?;
+        Note::with_attachments(assets, partial, recipient, attachments)
+    } else {
+        Note::new(assets, partial, recipient)
+    };
     Ok(note)
 }
 
@@ -67,8 +75,8 @@ pub async fn create_note_for_naming(
 
     let recipient = NoteRecipient::new(serial, note_script, inputs.clone());
     let tag = NoteTag::with_account_target(target_id);
-    let metadata = NoteMetadata::new(sender, NoteType::Public).with_tag(tag);
-    let note = Note::new(assets, metadata, recipient);
+    let partial = PartialNoteMetadata::new(sender, NoteType::Public).with_tag(tag);
+    let note = Note::new(assets, partial, recipient);
     Ok(note)
 }
 
@@ -90,9 +98,9 @@ pub fn generate_random_serial_number() -> Word {
     let mut rng = rand::rng();
 
     Word::new([
-        Felt::new(rng.random::<u32>() as u64),
-        Felt::new(rng.random::<u32>() as u64),
-        Felt::new(rng.random::<u32>() as u64),
-        Felt::new(rng.random::<u32>() as u64),
+        Felt::from(rng.random::<u32>()),
+        Felt::from(rng.random::<u32>()),
+        Felt::from(rng.random::<u32>()),
+        Felt::from(rng.random::<u32>()),
     ])
 }

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -28,14 +28,19 @@ pub fn naming_masm_path(is_network: bool) -> &'static str {
     }
 }
 
-/// Compiles a note script (linking the naming contract library) so its script root can be read.
-/// Used to build the network account's note-script allowlist.
-pub fn compile_naming_note_script(name: &str, is_network: bool) -> anyhow::Result<NoteScript> {
-    let note_code = fs::read_to_string(Path::new(&format!("./masm/notes/{}.masm", name)))?;
+/// Assembles the naming contract as a linkable [`Library`]. Assembling is non-trivial, so callers
+/// that compile several scripts should build this once and reuse it.
+pub fn naming_library(is_network: bool) -> anyhow::Result<Library> {
     let naming_code = fs::read_to_string(Path::new(naming_masm_path(is_network)))?;
-    let library = create_library(naming_code, "miden_name::naming")?;
+    create_library(naming_code, "miden_name::naming")
+}
+
+/// Compiles a note script against a pre-built naming [`Library`]. Its script root can then be read
+/// (e.g. to build the network account's note-script allowlist).
+pub fn compile_note_script_with_lib(name: &str, library: &Library) -> anyhow::Result<NoteScript> {
+    let note_code = fs::read_to_string(Path::new(&format!("./masm/notes/{}.masm", name)))?;
     let note_script = CodeBuilder::default()
-        .with_dynamically_linked_library(&library)?
+        .with_dynamically_linked_library(library)?
         .compile_note_script(note_code)?;
     Ok(note_script)
 }
@@ -46,10 +51,8 @@ pub fn compile_init_on_chain_tx_script(
     is_network: bool,
 ) -> anyhow::Result<miden_client::transaction::TransactionScript> {
     let script_code = fs::read_to_string(Path::new("./masm/scripts/init_on_chain.masm"))?;
-    let naming_code = fs::read_to_string(Path::new(naming_masm_path(is_network)))?;
-    let library = create_library(naming_code, "miden_name::naming")?;
     let tx_script = CodeBuilder::default()
-        .with_dynamically_linked_library(&library)?
+        .with_dynamically_linked_library(&naming_library(is_network)?)?
         .compile_tx_script(script_code)?;
     Ok(tx_script)
 }
@@ -63,10 +66,6 @@ pub async fn create_note_for_naming_with_client(
     is_network: bool,
     client: &mut Client<FilesystemKeyStore>,
 ) -> anyhow::Result<Note> {
-    let note_code = fs::read_to_string(Path::new(&format!("./masm/notes/{}.masm", name)))?;
-    let naming_code = fs::read_to_string(Path::new(naming_masm_path(is_network))).unwrap();
-    let library = create_library(naming_code, "miden_name::naming")?;
-
     let serial_num = Word::new([
         Felt::new(client.rng().next_u64())?,
         Felt::new(client.rng().next_u64())?,
@@ -74,9 +73,7 @@ pub async fn create_note_for_naming_with_client(
         Felt::new(client.rng().next_u64())?,
     ]);
 
-    let note_script = CodeBuilder::default()
-        .with_dynamically_linked_library(&library)?
-        .compile_note_script(note_code)?;
+    let note_script = compile_note_script_with_lib(&name, &naming_library(is_network)?)?;
 
     let recipient = NoteRecipient::new(serial_num, note_script, inputs.clone());
     let tag = NoteTag::with_account_target(target_id);

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -1,7 +1,7 @@
 use miden_client::{
     Client,
     account::AccountId,
-    asset::FungibleAsset,
+    asset::{AssetCallbackFlag, AssetVaultKey, FungibleAsset},
     keystore::FilesystemKeyStore,
     note::{Note, NoteAssets, NoteFile, NoteId, NoteStorage},
     store::NoteFilter,
@@ -89,8 +89,8 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         [
             deployer_account.id().suffix(),
             deployer_account.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0)?,
+            Felt::new(0)?,
         ]
         .to_vec(),
     )?;
@@ -100,6 +100,7 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         deployer_account.id(),
         naming_account.id(),
         NoteAssets::new(vec![]).unwrap(),
+        is_network,
         &mut client,
     )
     .await?;
@@ -163,6 +164,7 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         deployer_account.id(),
         naming_account.id(),
         NoteAssets::new(vec![]).unwrap(),
+        is_network,
         &mut client,
     )
     .await?;
@@ -209,10 +211,10 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         let prices_slot = slot_name("naming::prices");
 
         let one_letter_word = Word::new([
-            Felt::new(payment_token_id.suffix().as_canonical_u64()),
+            payment_token_id.suffix(),
             payment_token_id.prefix().as_felt(),
-            Felt::new(1),
-            Felt::new(0),
+            Felt::new(1)?,
+            Felt::new(0)?,
         ]);
         let one_letter_price: Word = account
             .storage()
@@ -222,10 +224,10 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         println!("one letter price value: {}", one_letter_price.to_string());
 
         let two_letter_word = Word::new([
-            Felt::new(payment_token_id.suffix().as_canonical_u64()),
+            payment_token_id.suffix(),
             payment_token_id.prefix().as_felt(),
-            Felt::new(2),
-            Felt::new(0),
+            Felt::new(2)?,
+            Felt::new(0)?,
         ]);
         let two_letter_price: Word = account
             .storage()
@@ -235,10 +237,10 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         println!("two letter price value: {}", two_letter_price.to_string());
 
         let three_letter_word = Word::new([
-            Felt::new(payment_token_id.suffix().as_canonical_u64()),
+            payment_token_id.suffix(),
             payment_token_id.prefix().as_felt(),
-            Felt::new(3),
-            Felt::new(0),
+            Felt::new(3)?,
+            Felt::new(0)?,
         ]);
         let three_letter_price: Word = account
             .storage()
@@ -251,10 +253,10 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         );
 
         let four_letter_word = Word::new([
-            Felt::new(payment_token_id.suffix().as_canonical_u64()),
+            payment_token_id.suffix(),
             payment_token_id.prefix().as_felt(),
-            Felt::new(4),
-            Felt::new(0),
+            Felt::new(4)?,
+            Felt::new(0)?,
         ]);
         let four_letter_price: Word = account
             .storage()
@@ -264,10 +266,10 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         println!("four letter price value: {}", four_letter_price.to_string());
 
         let five_letter_word = Word::new([
-            Felt::new(payment_token_id.suffix().as_canonical_u64()),
+            payment_token_id.suffix(),
             payment_token_id.prefix().as_felt(),
-            Felt::new(5),
-            Felt::new(0),
+            Felt::new(5)?,
+            Felt::new(0)?,
         ]);
         let five_letter_price: Word = account
             .storage()
@@ -350,6 +352,7 @@ pub async fn send_register_note(
     naming_account: String,
     faucet_id: String,
     name: String,
+    is_network: bool,
     use_testnet: bool,
 ) -> anyhow::Result<()> {
     println!("\n[Sending register note]");
@@ -367,13 +370,18 @@ pub async fn send_register_note(
     safe_account_import(&mut client, account).await?;
     safe_account_import(&mut client, naming_account).await?;
 
-    let is_network = naming_account.is_network();
+    // 0.15: network status is no longer encoded in the AccountId; it is supplied explicitly
+    // (matching the deploy-time `--as-network` flag).
 
     println!("Checking balance of sender account");
 
     let account_record = client.get_account(account).await?.unwrap();
     let full_account: miden_protocol::account::Account = account_record.try_into()?;
-    let balance = full_account.vault().get_balance(faucet_id)?;
+    // 0.15: get_balance takes an AssetVaultKey and returns AssetAmount.
+    let balance: u64 = full_account
+        .vault()
+        .get_balance(AssetVaultKey::new_fungible(faucet_id, AssetCallbackFlag::Disabled))?
+        .into();
 
     let price = get_price_by_length(&name);
 
@@ -400,8 +408,8 @@ pub async fn send_register_note(
         [
             faucet_id.suffix(),
             faucet_id.prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0)?,
+            Felt::new(0)?,
             domain[0],
             domain[1],
             domain[2],
@@ -418,6 +426,7 @@ pub async fn send_register_note(
         account,
         naming_account,
         register_asset,
+        is_network,
         &mut client,
     )
     .await?;

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -81,8 +81,8 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         [
             deployer_account.id().suffix(),
             deployer_account.id().prefix().as_felt(),
-            Felt::new(0)?,
-            Felt::new(0)?,
+            Felt::from(0u32),
+            Felt::from(0u32),
         ]
         .to_vec(),
     )?;
@@ -202,73 +202,21 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         let account: miden_protocol::account::Account = record.try_into().unwrap();
         let prices_slot = slot_name("naming::prices");
 
-        let one_letter_word = Word::new([
-            payment_token_id.suffix(),
-            payment_token_id.prefix().as_felt(),
-            Felt::new(1)?,
-            Felt::new(0)?,
-        ]);
-        let one_letter_price: Word = account
-            .storage()
-            .get_map_item(&prices_slot, reverse_word(one_letter_word))
-            .unwrap()
-            .into();
-        println!("one letter price value: {}", one_letter_price.to_string());
-
-        let two_letter_word = Word::new([
-            payment_token_id.suffix(),
-            payment_token_id.prefix().as_felt(),
-            Felt::new(2)?,
-            Felt::new(0)?,
-        ]);
-        let two_letter_price: Word = account
-            .storage()
-            .get_map_item(&prices_slot, reverse_word(two_letter_word))
-            .unwrap()
-            .into();
-        println!("two letter price value: {}", two_letter_price.to_string());
-
-        let three_letter_word = Word::new([
-            payment_token_id.suffix(),
-            payment_token_id.prefix().as_felt(),
-            Felt::new(3)?,
-            Felt::new(0)?,
-        ]);
-        let three_letter_price: Word = account
-            .storage()
-            .get_map_item(&prices_slot, reverse_word(three_letter_word))
-            .unwrap()
-            .into();
-        println!(
-            "three letter price value: {}",
-            three_letter_price.to_string()
-        );
-
-        let four_letter_word = Word::new([
-            payment_token_id.suffix(),
-            payment_token_id.prefix().as_felt(),
-            Felt::new(4)?,
-            Felt::new(0)?,
-        ]);
-        let four_letter_price: Word = account
-            .storage()
-            .get_map_item(&prices_slot, reverse_word(four_letter_word))
-            .unwrap()
-            .into();
-        println!("four letter price value: {}", four_letter_price.to_string());
-
-        let five_letter_word = Word::new([
-            payment_token_id.suffix(),
-            payment_token_id.prefix().as_felt(),
-            Felt::new(5)?,
-            Felt::new(0)?,
-        ]);
-        let five_letter_price: Word = account
-            .storage()
-            .get_map_item(&prices_slot, reverse_word(five_letter_word))
-            .unwrap()
-            .into();
-        println!("five letter price value: {}", five_letter_price.to_string());
+        for len in 1..=5u32 {
+            // 0.15: map lookups use the reversed key, and the returned value is reversed too.
+            let key = Word::new([
+                payment_token_id.suffix(),
+                payment_token_id.prefix().as_felt(),
+                Felt::from(len),
+                Felt::from(0u32),
+            ]);
+            let price: Word = account
+                .storage()
+                .get_map_item(&prices_slot, reverse_word(key))
+                .unwrap()
+                .into();
+            println!("{len} letter price value: {price}");
+        }
     }
 
     Ok(())
@@ -400,8 +348,8 @@ pub async fn send_register_note(
         [
             faucet_id.suffix(),
             faucet_id.prefix().as_felt(),
-            Felt::new(0)?,
-            Felt::new(0)?,
+            Felt::from(0u32),
+            Felt::from(0u32),
             domain[0],
             domain[1],
             domain[2],

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -15,7 +15,7 @@ use tokio::time::{Duration, sleep};
 use crate::{
     accounts::{create_deployer_account, create_naming_account, safe_account_import},
     client::{create_keystore, initiate_client},
-    domain::encode_domain,
+    domain::{encode_domain, reverse_word},
     notes::{create_library, create_note_for_naming_with_client},
     storage::slot_name,
     transaction::wait_for_tx,
@@ -32,7 +32,7 @@ fn midenscan_base_url(use_testnet: bool) -> &'static str {
 
 fn default_faucet_id(use_testnet: bool) -> &'static str {
     if use_testnet {
-        "0x0a7d175ed63ec5200fb2ced86f6aa5"
+        "0x2458e5446128e6b150b75b8ebd9ce1"
     } else {
         "0x16f6c85d5652c9200879145bfdda93"
     }
@@ -218,7 +218,7 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         ]);
         let one_letter_price: Word = account
             .storage()
-            .get_map_item(&prices_slot, one_letter_word)
+            .get_map_item(&prices_slot, reverse_word(one_letter_word))
             .unwrap()
             .into();
         println!("one letter price value: {}", one_letter_price.to_string());
@@ -231,7 +231,7 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         ]);
         let two_letter_price: Word = account
             .storage()
-            .get_map_item(&prices_slot, two_letter_word)
+            .get_map_item(&prices_slot, reverse_word(two_letter_word))
             .unwrap()
             .into();
         println!("two letter price value: {}", two_letter_price.to_string());
@@ -244,7 +244,7 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         ]);
         let three_letter_price: Word = account
             .storage()
-            .get_map_item(&prices_slot, three_letter_word)
+            .get_map_item(&prices_slot, reverse_word(three_letter_word))
             .unwrap()
             .into();
         println!(
@@ -260,7 +260,7 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         ]);
         let four_letter_price: Word = account
             .storage()
-            .get_map_item(&prices_slot, four_letter_word)
+            .get_map_item(&prices_slot, reverse_word(four_letter_word))
             .unwrap()
             .into();
         println!("four letter price value: {}", four_letter_price.to_string());
@@ -273,7 +273,7 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
         ]);
         let five_letter_price: Word = account
             .storage()
-            .get_map_item(&prices_slot, five_letter_word)
+            .get_map_item(&prices_slot, reverse_word(five_letter_word))
             .unwrap()
             .into();
         println!("five letter price value: {}", five_letter_price.to_string());

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -16,7 +16,7 @@ use crate::{
     accounts::{create_deployer_account, create_naming_account, safe_account_import},
     client::{create_keystore, initiate_client},
     domain::{encode_domain, reverse_word},
-    notes::{create_library, create_note_for_naming_with_client},
+    notes::create_note_for_naming_with_client,
     storage::slot_name,
     transaction::wait_for_tx,
     utils::get_price_by_length,
@@ -56,17 +56,9 @@ pub async fn deploy(is_network: bool, use_testnet: bool) -> anyhow::Result<()> {
     let deployer_account = create_deployer_account(&mut client, &mut keystore).await?;
     let naming_account = create_naming_account(&mut client, is_network).await?;
 
-    // Init note
-    let script_code = fs::read_to_string(Path::new("./masm/scripts/init_on_chain.masm")).unwrap();
-
-    let account_code = fs::read_to_string(Path::new("./masm/accounts/naming_unsafe.masm")).unwrap();
-    let library_path = "miden_name::naming";
-
-    let library = create_library(account_code, library_path)?;
-
-    let tx_script = CodeBuilder::default()
-        .with_dynamically_linked_library(&library)?
-        .compile_tx_script(script_code)?;
+    // Init note — compiled via the shared helper so its root matches the network account's
+    // tx-script allowlist.
+    let tx_script = crate::notes::compile_init_on_chain_tx_script(is_network)?;
 
     let tx_init_request = TransactionRequestBuilder::new()
         .custom_script(tx_script)

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -6,7 +6,6 @@ use miden_client::{
     transaction::{TransactionId, TransactionScript, TransactionStatus},
 };
 use miden_standards::code_builder::CodeBuilder;
-use tokio::time::{Duration, sleep};
 
 pub async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,

--- a/tests/encoding_test.rs
+++ b/tests/encoding_test.rs
@@ -8,10 +8,10 @@ fn encode_letter() {
     let encoded: Word = encode_domain(letter);
     let felts: Vec<Felt> = encoded.to_vec();
 
-    assert_eq!(felts[0], Felt::new(0));
-    assert_eq!(felts[1], Felt::new(0));
-    assert_eq!(felts[2], Felt::new(1));
-    assert_eq!(felts[3], Felt::new(1));
+    assert_eq!(felts[0], Felt::new(0).unwrap());
+    assert_eq!(felts[1], Felt::new(0).unwrap());
+    assert_eq!(felts[2], Felt::new(1).unwrap());
+    assert_eq!(felts[3], Felt::new(1).unwrap());
 }
 
 #[test]
@@ -21,10 +21,10 @@ fn encode_letters() {
     let encoded: Word = encode_domain(domain);
     let felts: Vec<Felt> = encoded.to_vec();
 
-    assert_eq!(felts[0], Felt::new(0));
-    assert_eq!(felts[1], Felt::new(0));
-    assert_eq!(felts[2], Felt::new(0x503090c01));
-    assert_eq!(felts[3], Felt::new(5));
+    assert_eq!(felts[0], Felt::new(0).unwrap());
+    assert_eq!(felts[1], Felt::new(0).unwrap());
+    assert_eq!(felts[2], Felt::new(0x503090c01).unwrap());
+    assert_eq!(felts[3], Felt::new(5).unwrap());
 }
 
 #[test]
@@ -32,10 +32,10 @@ fn decode_letters() {
     let encoded: u64 = 0x503090c01;
 
     let encoded_word: Word = Word::new([
-        Felt::new(0),
-        Felt::new(0),
-        Felt::new(encoded),
-        Felt::new(5_u64),
+        Felt::new(0).unwrap(),
+        Felt::new(0).unwrap(),
+        Felt::new(encoded).unwrap(),
+        Felt::new(5_u64).unwrap(),
     ]);
 
     let decoded_domain: String = decode_domain(encoded_word);
@@ -49,19 +49,19 @@ fn encode_multiple_felts() {
 
     let felts = encoded.to_vec();
 
-    assert_eq!(felts[0], Felt::new(0x050f0a)); // joe
-    assert_eq!(felts[1], Felt::new(0x40e01020f0204)); // dboband
-    assert_eq!(felts[2], Felt::new(0xe010503090c01)); // alicean
-    assert_eq!(felts[3], Felt::new(17));
+    assert_eq!(felts[0], Felt::new(0x050f0a).unwrap()); // joe
+    assert_eq!(felts[1], Felt::new(0x40e01020f0204).unwrap()); // dboband
+    assert_eq!(felts[2], Felt::new(0xe010503090c01).unwrap()); // alicean
+    assert_eq!(felts[3], Felt::new(17).unwrap());
 }
 
 #[test]
 fn decode_multiple_felts() {
     let encoded_word: Word = Word::new([
-        Felt::new(0x50f0a),
-        Felt::new(0x40e01020f0204),
-        Felt::new(0xe010503090c01),
-        Felt::new(17_u64),
+        Felt::new(0x50f0a).unwrap(),
+        Felt::new(0x40e01020f0204).unwrap(),
+        Felt::new(0xe010503090c01).unwrap(),
+        Felt::new(17_u64).unwrap(),
     ]);
 
     let decoded_domain = decode_domain(encoded_word);

--- a/tests/naming_protocol_tests.rs
+++ b/tests/naming_protocol_tests.rs
@@ -5,7 +5,7 @@ use miden_client::{
     note::{NoteAssets, NoteStorage, NoteTag, NoteType},
 };
 use miden_crypto::{Felt, Word};
-use midenname_contracts::domain::encode_domain_as_felts;
+use midenname_contracts::domain::{encode_domain_as_felts, reverse_word};
 use midenname_contracts::storage::slot_name;
 use test_utils::init_naming;
 
@@ -23,10 +23,10 @@ async fn test_double_init_fails() -> anyhow::Result<()> {
     // Create a second init note with custom serial to avoid NoteId collision
     let init_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.owner.id().suffix().as_canonical_u64()),
+            ctx.owner.id().suffix(),
             ctx.owner.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -36,7 +36,7 @@ async fn test_double_init_fails() -> anyhow::Result<()> {
         ctx.owner.id(),
         ctx.naming.id(),
         NoteAssets::new(vec![])?,
-        Word::new([Felt::new(99), Felt::new(0), Felt::new(0), Felt::new(0)]),
+        Word::new([Felt::new(99).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap()]),
     )
     .await?;
     add_note_to_builder(&mut ctx.builder, second_init_note.clone())?;
@@ -72,7 +72,7 @@ async fn test_prices_updated_with_testnet_script() -> anyhow::Result<()> {
     // Send testnet prices (different from default) — use custom serial_num to avoid collision
     let price_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
         ]
         .to_vec(),
@@ -83,7 +83,7 @@ async fn test_prices_updated_with_testnet_script() -> anyhow::Result<()> {
         ctx.owner.id(),
         ctx.naming.id(),
         NoteAssets::new(vec![])?,
-        Word::new([Felt::new(10), Felt::new(0), Felt::new(0), Felt::new(0)]),
+        Word::new([Felt::new(10).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap()]),
     )
     .await?;
     add_note_to_builder(&mut ctx.builder, testnet_prices_note.clone())?;
@@ -97,49 +97,51 @@ async fn test_prices_updated_with_testnet_script() -> anyhow::Result<()> {
 
     // Verify original prices (4-letter = 555)
     let price_key = Word::new([
-        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        ctx.fungible_asset.faucet_id().suffix(),
         ctx.fungible_asset.faucet_id().prefix().as_felt(),
-        Felt::new(4),
-        Felt::new(0),
+        Felt::new(4).unwrap(),
+        Felt::new(0).unwrap(),
     ]);
-    let price_before = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::prices"), price_key)?;
-    assert_eq!(price_before.get(3).unwrap().as_canonical_u64(), 555);
+    let price_before = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::prices"), reverse_word(price_key))?,
+    );
+    assert_eq!(price_before.get(0).unwrap().as_canonical_u64(), 555);
 
     // Apply testnet prices
     execute_note(&mut chain, testnet_prices_note.id(), &mut ctx.naming).await?;
 
     // Verify testnet prices: 4-letter = 55_000_000
-    let price_after = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::prices"), price_key)?;
-    assert_eq!(price_after.get(3).unwrap().as_canonical_u64(), 55_000_000);
+    let price_after = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::prices"), reverse_word(price_key))?,
+    );
+    assert_eq!(price_after.get(0).unwrap().as_canonical_u64(), 55_000_000);
 
     // Verify other testnet prices
-    let price_1 = ctx.naming.storage().get_map_item(
+    let price_1 = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::prices"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(1),
-            Felt::new(0),
-        ]),
-    )?;
-    assert_eq!(price_1.get(3).unwrap().as_canonical_u64(), 375_000_000);
+            Felt::new(1).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
+    assert_eq!(price_1.get(0).unwrap().as_canonical_u64(), 375_000_000);
 
-    let price_5 = ctx.naming.storage().get_map_item(
+    let price_5 = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::prices"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(5),
-            Felt::new(0),
-        ]),
-    )?;
-    assert_eq!(price_5.get(3).unwrap().as_canonical_u64(), 20_000_000);
+            Felt::new(5).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
+    assert_eq!(price_5.get(0).unwrap().as_canonical_u64(), 20_000_000);
 
     Ok(())
 }
@@ -152,10 +154,10 @@ async fn test_revenue_accumulates_across_registrations() -> anyhow::Result<()> {
     let domain1 = encode_domain_as_felts("test".to_string());
     let register1_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain1[0],
             domain1[1],
             domain1[2],
@@ -178,10 +180,10 @@ async fn test_revenue_accumulates_across_registrations() -> anyhow::Result<()> {
     let domain2 = encode_domain_as_felts("alpha".to_string());
     let register2_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain2[0],
             domain2[1],
             domain2[2],
@@ -204,10 +206,10 @@ async fn test_revenue_accumulates_across_registrations() -> anyhow::Result<()> {
     let domain3 = encode_domain_as_felts("hey".to_string());
     let register3_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain3[0],
             domain3[1],
             domain3[2],
@@ -241,26 +243,28 @@ async fn test_revenue_accumulates_across_registrations() -> anyhow::Result<()> {
 
     // Assert: total_revenue = 555 + 123 + 789 = 1467
     let revenue_key = Word::new([
-        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        ctx.fungible_asset.faucet_id().suffix(),
         ctx.fungible_asset.faucet_id().prefix().as_felt(),
-        Felt::new(0),
-        Felt::new(0),
+        Felt::new(0).unwrap(),
+        Felt::new(0).unwrap(),
     ]);
-    let total_revenue = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::total_revenue"), revenue_key)?;
+    let total_revenue = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::total_revenue"), reverse_word(revenue_key))?,
+    );
     assert_eq!(
-        total_revenue.get(3).unwrap().as_canonical_u64(),
+        total_revenue.get(0).unwrap().as_canonical_u64(),
         555 + 123 + 789
     );
 
     // Assert: domain_count = 3
-    let domain_count = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::domain_count"))?;
-    assert_eq!(domain_count.get(3).unwrap().as_canonical_u64(), 3);
+    let domain_count = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::domain_count"))?,
+    );
+    assert_eq!(domain_count.get(0).unwrap().as_canonical_u64(), 3);
 
     Ok(())
 }
@@ -273,10 +277,10 @@ async fn test_claim_protocol_revenue() -> anyhow::Result<()> {
     let domain = encode_domain_as_felts("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -311,23 +315,24 @@ async fn test_claim_protocol_revenue() -> anyhow::Result<()> {
     // Contract drops bottom 2, leaving [pos7, pos6] = [tag, note_type]
     let claim_note_inputs = NoteStorage::new(
         [
-            // RECIPIENT (positions 0-3)
-            p2id_recipient[0],
-            p2id_recipient[1],
-            p2id_recipient[2],
+            // RECIPIENT (positions 0-3): passed reversed so the contract's mem_loadw_be
+            // (which reverses the word in 0.15) reconstructs the correct recipient digest.
             p2id_recipient[3],
+            p2id_recipient[2],
+            p2id_recipient[1],
+            p2id_recipient[0],
             // NOTE_DETAILS (positions 4-7): note_type, tag, padding, padding
             // After mem_loadw_be: [pos7, pos6, pos5, pos4] = [0, 0, tag, note_type]
             // After drop drop: [tag, note_type] which is what output_note::create needs
             NoteType::Public.into(),
             tag.into(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             // TOKEN (positions 8-11): suffix, prefix, 0, 0
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -361,21 +366,23 @@ async fn test_claim_protocol_revenue() -> anyhow::Result<()> {
 
     // Assert: claimed_revenue = total_revenue = 555
     let revenue_key = Word::new([
-        Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        ctx.fungible_asset.faucet_id().suffix(),
         ctx.fungible_asset.faucet_id().prefix().as_felt(),
-        Felt::new(0),
-        Felt::new(0),
+        Felt::new(0).unwrap(),
+        Felt::new(0).unwrap(),
     ]);
-    let total_revenue = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::total_revenue"), revenue_key)?;
-    assert_eq!(total_revenue.get(3).unwrap().as_canonical_u64(), 555);
-    let claimed_revenue = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::claimed_revenue"), revenue_key)?;
-    assert_eq!(claimed_revenue.get(3).unwrap().as_canonical_u64(), 555);
+    let total_revenue = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::total_revenue"), reverse_word(revenue_key))?,
+    );
+    assert_eq!(total_revenue.get(0).unwrap().as_canonical_u64(), 555);
+    let claimed_revenue = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::claimed_revenue"), reverse_word(revenue_key))?,
+    );
+    assert_eq!(claimed_revenue.get(0).unwrap().as_canonical_u64(), 555);
 
     Ok(())
 }
@@ -388,10 +395,10 @@ async fn test_withdraw_assets() -> anyhow::Result<()> {
     let domain = encode_domain_as_felts("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -424,21 +431,22 @@ async fn test_withdraw_assets() -> anyhow::Result<()> {
     // Note inputs: RECIPIENT (pos 0-3), NOTE_DETAILS (pos 4-7), TOKEN (pos 8-11)
     let withdraw_note_inputs = NoteStorage::new(
         [
-            // RECIPIENT (positions 0-3)
-            p2id_recipient[0],
-            p2id_recipient[1],
-            p2id_recipient[2],
+            // RECIPIENT (positions 0-3): passed reversed so the contract's mem_loadw_be
+            // (which reverses the word in 0.15) reconstructs the correct recipient digest.
             p2id_recipient[3],
+            p2id_recipient[2],
+            p2id_recipient[1],
+            p2id_recipient[0],
             // NOTE_DETAILS (positions 4-7): note_type, tag, padding, padding
             NoteType::Public.into(),
             tag.into(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             // TOKEN (positions 8-11): suffix, prefix, 0, 0
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;

--- a/tests/naming_referral_tests.rs
+++ b/tests/naming_referral_tests.rs
@@ -5,7 +5,9 @@ use miden_client::{
     note::{NoteAssets, NoteStorage},
 };
 use miden_crypto::{Felt, Word};
-use midenname_contracts::domain::{encode_domain, encode_domain_as_felts, unsafe_encode_domain};
+use midenname_contracts::domain::{
+    encode_domain, encode_domain_as_felts, reverse_word, unsafe_encode_domain,
+};
 use midenname_contracts::storage::slot_name;
 use test_utils::init_naming;
 
@@ -20,14 +22,14 @@ async fn test_naming_register_under_referrer() -> anyhow::Result<()> {
 
     let set_ref_rate_inputs = NoteStorage::new(
         [
-            Felt::new(2000),
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            Felt::new(2000).unwrap(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -46,22 +48,22 @@ async fn test_naming_register_under_referrer() -> anyhow::Result<()> {
     let domain_word = encode_domain("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
             domain[3],
-            Felt::new(1), // register length
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(1).unwrap(), // register length
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -90,27 +92,30 @@ async fn test_naming_register_under_referrer() -> anyhow::Result<()> {
     )
     .await?;
 
-    let domain_owner_slot = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    let domain_expiry_slot = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_expiry"), domain_word)?;
-    let domain_to_id = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
-    let id_to_domain = ctx.naming.storage().get_map_item(
+    let domain_owner_slot = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
+    );
+    let domain_expiry_slot = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_expiry"), reverse_word(domain_word))?,
+    );
+    let domain_to_id = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_account"), reverse_word(domain_word))?,
+    );
+    let id_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.registrar_1.id().suffix(),
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
 
     assert_eq!(
         domain_owner_slot.get(0).unwrap().as_canonical_u64(),
@@ -132,28 +137,28 @@ async fn test_naming_register_under_referrer() -> anyhow::Result<()> {
 
     // Protocol values
 
-    let total_revenue_slot = ctx.naming.storage().get_map_item(
+    let total_revenue_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::total_revenue"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(total_revenue_slot.get(0).unwrap().as_canonical_u64(), 444);
 
     // Referrer values
 
-    let referrer_slot = ctx.naming.storage().get_map_item(
+    let referrer_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::ref_total_revenue"),
-        Word::new([
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(referrer_slot.get(0).unwrap().as_canonical_u64(), 111);
     Ok(())
 }
@@ -165,14 +170,14 @@ async fn test_naming_referrer_revenue_accumulation() -> anyhow::Result<()> {
 
     let set_ref_rate_inputs = NoteStorage::new(
         [
-            Felt::new(2000),
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            Felt::new(2000).unwrap(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -191,22 +196,22 @@ async fn test_naming_referrer_revenue_accumulation() -> anyhow::Result<()> {
     let domain_word = encode_domain("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
             domain[3],
-            Felt::new(1), // register length
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(1).unwrap(), // register length
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -227,22 +232,22 @@ async fn test_naming_referrer_revenue_accumulation() -> anyhow::Result<()> {
     let domain_word_2 = encode_domain("test2".to_string());
     let register_note_inputs_2 = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain_2[0],
             domain_2[1],
             domain_2[2],
             domain_2[3],
-            Felt::new(1), // register length
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(1).unwrap(), // register length
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -255,7 +260,7 @@ async fn test_naming_referrer_revenue_accumulation() -> anyhow::Result<()> {
         ctx.registrar_1.id(),
         ctx.naming.id(),
         register_asset,
-        Word::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(1)]),
+        Word::new([Felt::new(1).unwrap(), Felt::new(2).unwrap(), Felt::new(3).unwrap(), Felt::new(1).unwrap()]),
     )
     .await?;
     add_note_to_builder(&mut ctx.builder, register_note_2.clone())?;
@@ -275,28 +280,28 @@ async fn test_naming_referrer_revenue_accumulation() -> anyhow::Result<()> {
 
     // Protocol values
 
-    let total_revenue_slot = ctx.naming.storage().get_map_item(
+    let total_revenue_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::total_revenue"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(total_revenue_slot.get(0).unwrap().as_canonical_u64(), 543);
 
     // Referrer values
 
-    let referrer_slot = ctx.naming.storage().get_map_item(
+    let referrer_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::ref_total_revenue"),
-        Word::new([
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(referrer_slot.get(0).unwrap().as_canonical_u64(), 135);
     Ok(())
 }

--- a/tests/naming_register_tests.rs
+++ b/tests/naming_register_tests.rs
@@ -5,7 +5,9 @@ use miden_client::{
     note::{NoteAssets, NoteStorage},
 };
 use miden_crypto::{Felt, Word};
-use midenname_contracts::domain::{encode_domain, encode_domain_as_felts, unsafe_encode_domain};
+use midenname_contracts::domain::{
+    encode_domain, encode_domain_as_felts, reverse_word, unsafe_encode_domain,
+};
 use midenname_contracts::storage::slot_name;
 use test_utils::init_naming;
 
@@ -23,11 +25,14 @@ async fn test_naming_initialize() -> anyhow::Result<()> {
     execute_note(&mut chain, ctx.initialize_note.id(), &mut ctx.naming).await?;
     execute_note(&mut chain, ctx.set_prices_note.id(), &mut ctx.naming).await?;
 
-    let init_slot = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::init_flag"))?;
-    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    // 0.15: Words read back from MASM storage have reversed element order vs 0.14,
+    // so reverse them to restore the [a,b,c,d] layout the assertions expect.
+    let init_slot = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::init_flag"))?,
+    );
+    let owner_slot = reverse_word(ctx.naming.storage().get_item(&slot_name("naming::owner"))?);
 
     assert_eq!(init_slot.get(0).unwrap().as_canonical_u64(), 1);
     assert_eq!(
@@ -42,15 +47,18 @@ async fn test_naming_initialize() -> anyhow::Result<()> {
     // Assert prices
     let mock_prices = get_test_prices();
     for i in 1..=5 {
-        let price_slot = ctx.naming.storage().get_map_item(
-            &slot_name("naming::prices"),
-            Word::new([
-                Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
-                ctx.fungible_asset.faucet_id().prefix().as_felt(),
-                Felt::new(i as u64),
-                Felt::new(0),
-            ]),
-        )?;
+        let price_key = Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
+            ctx.fungible_asset.faucet_id().prefix().as_felt(),
+            Felt::new(i as u64).unwrap(),
+            Felt::new(0).unwrap(),
+        ]);
+        // 0.15: map lookups must use the reversed key, and the returned value is reversed too.
+        let price_slot = reverse_word(
+            ctx.naming
+                .storage()
+                .get_map_item(&slot_name("naming::prices"), reverse_word(price_key))?,
+        );
         assert_eq!(
             price_slot.get(0).unwrap().as_canonical_u64(),
             mock_prices[i as usize].as_canonical_u64()
@@ -68,10 +76,10 @@ async fn test_naming_register_activate() -> anyhow::Result<()> {
     let domain_word = encode_domain("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -112,30 +120,35 @@ async fn test_naming_register_activate() -> anyhow::Result<()> {
     .await?;
     //execute_note(&mut ctx.chain, note, &mut ctx.naming).await?;
 
-    let domain_owner_slot = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    let domain_to_id = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
-    let id_to_domain = ctx.naming.storage().get_map_item(
+    let domain_owner_slot = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
+    );
+    let domain_to_id = reverse_word(
+        ctx.naming.storage().get_map_item(
+            &slot_name("naming::domain_to_account"),
+            reverse_word(domain_word),
+        )?,
+    );
+    let id_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            ctx.registrar_1.id().suffix(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
 
+    // 0.15: account-id pairs stored in maps come back as [prefix, suffix, 0, 0] after reverse_word
+    // (padding-front layout), so suffix is at index 1 and prefix at index 0.
     assert_eq!(
-        domain_owner_slot.get(0).unwrap().as_canonical_u64(),
+        domain_owner_slot.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     );
     assert_eq!(
-        domain_owner_slot.get(1).unwrap().as_canonical_u64(),
+        domain_owner_slot.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
 
@@ -146,47 +159,50 @@ async fn test_naming_register_activate() -> anyhow::Result<()> {
 
     // Protocol values
 
-    let total_revenue_slot = ctx.naming.storage().get_map_item(
+    let total_revenue_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::total_revenue"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(total_revenue_slot.get(0).unwrap().as_canonical_u64(), 555);
 
-    let total_domain_count = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::domain_count"))?;
+    let total_domain_count = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::domain_count"))?,
+    );
     assert_eq!(total_domain_count.get(0).unwrap().as_canonical_u64(), 1);
 
     // Activate domain
 
     execute_note(&mut chain, activate_note.id(), &mut ctx.naming).await?; // Use always updated account as target
 
-    let domain_to_id = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
-    let id_to_domain = ctx.naming.storage().get_map_item(
+    let domain_to_id = reverse_word(
+        ctx.naming.storage().get_map_item(
+            &slot_name("naming::domain_to_account"),
+            reverse_word(domain_word),
+        )?,
+    );
+    let id_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            ctx.registrar_1.id().suffix(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
 
     assert_eq!(
-        domain_to_id.get(0).unwrap().as_canonical_u64(),
+        domain_to_id.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     ); // Now domain mapping must be matched
     assert_eq!(
-        domain_to_id.get(1).unwrap().as_canonical_u64(),
+        domain_to_id.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
     assert_eq!(id_to_domain, domain_word);
@@ -201,10 +217,10 @@ async fn test_naming_register_activate_by_not_owner() -> anyhow::Result<()> {
     let domain_word = encode_domain("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -243,30 +259,35 @@ async fn test_naming_register_activate_by_not_owner() -> anyhow::Result<()> {
     .await?;
     execute_note(&mut chain, register_note.id(), &mut ctx.naming).await?;
 
-    let domain_owner_slot = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    let domain_to_id = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
-    let id_to_domain = ctx.naming.storage().get_map_item(
+    let domain_owner_slot = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
+    );
+    let domain_to_id = reverse_word(
+        ctx.naming.storage().get_map_item(
+            &slot_name("naming::domain_to_account"),
+            reverse_word(domain_word),
+        )?,
+    );
+    let id_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            ctx.registrar_1.id().suffix(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
 
+    // 0.15: account-id pairs stored in maps come back as [prefix, suffix, 0, 0] after reverse_word
+    // (padding-front layout), so suffix is at index 1 and prefix at index 0.
     assert_eq!(
-        domain_owner_slot.get(0).unwrap().as_canonical_u64(),
+        domain_owner_slot.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     );
     assert_eq!(
-        domain_owner_slot.get(1).unwrap().as_canonical_u64(),
+        domain_owner_slot.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
 
@@ -277,21 +298,22 @@ async fn test_naming_register_activate_by_not_owner() -> anyhow::Result<()> {
 
     // Protocol values
 
-    let total_revenue_slot = ctx.naming.storage().get_map_item(
+    let total_revenue_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::total_revenue"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(total_revenue_slot.get(0).unwrap().as_canonical_u64(), 555);
 
-    let total_domain_count = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::domain_count"))?;
+    let total_domain_count = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::domain_count"))?,
+    );
     assert_eq!(total_domain_count.get(0).unwrap().as_canonical_u64(), 1);
 
     // Activate domain - should fail because registrar_2 is not the owner
@@ -313,10 +335,10 @@ async fn test_naming_register_already_exist_domain() -> anyhow::Result<()> {
     let domain = encode_domain_as_felts("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -377,10 +399,10 @@ async fn test_naming_register_already_exist_domain_from_same_owner() -> anyhow::
     let domain = encode_domain_as_felts("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -442,10 +464,10 @@ async fn test_naming_register_two_domains_activate_after() -> anyhow::Result<()>
     // Notes
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -479,18 +501,18 @@ async fn test_naming_register_two_domains_activate_after() -> anyhow::Result<()>
     let second_domain_word = encode_domain("test2".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             second_domain[0],
             second_domain[1],
             second_domain[2],
             second_domain[3],
-            Felt::new(1), // register length
-            Felt::new(0),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(1).unwrap(), // register length
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -526,30 +548,35 @@ async fn test_naming_register_two_domains_activate_after() -> anyhow::Result<()>
     .await?;
     execute_note(&mut chain, register_note_1.id(), &mut ctx.naming).await?;
 
-    let domain_owner_slot = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    let domain_to_id = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
-    let id_to_domain = ctx.naming.storage().get_map_item(
+    let domain_owner_slot = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
+    );
+    let domain_to_id = reverse_word(
+        ctx.naming.storage().get_map_item(
+            &slot_name("naming::domain_to_account"),
+            reverse_word(domain_word),
+        )?,
+    );
+    let id_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            ctx.registrar_1.id().suffix(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
 
+    // 0.15: account-id pairs stored in maps come back as [prefix, suffix, 0, 0] after reverse_word
+    // (padding-front layout), so suffix is at index 1 and prefix at index 0.
     assert_eq!(
-        domain_owner_slot.get(0).unwrap().as_canonical_u64(),
+        domain_owner_slot.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     );
     assert_eq!(
-        domain_owner_slot.get(1).unwrap().as_canonical_u64(),
+        domain_owner_slot.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
 
@@ -560,47 +587,50 @@ async fn test_naming_register_two_domains_activate_after() -> anyhow::Result<()>
 
     // Protocol values
 
-    let total_revenue_slot = ctx.naming.storage().get_map_item(
+    let total_revenue_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::total_revenue"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(total_revenue_slot.get(0).unwrap().as_canonical_u64(), 555);
 
-    let total_domain_count = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::domain_count"))?;
+    let total_domain_count = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::domain_count"))?,
+    );
     assert_eq!(total_domain_count.get(0).unwrap().as_canonical_u64(), 1);
 
     // Activate domain
 
     execute_note(&mut chain, activate_note_1.id(), &mut ctx.naming).await?; // Use always updated account as target
 
-    let domain_to_id = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
-    let id_to_domain = ctx.naming.storage().get_map_item(
+    let domain_to_id = reverse_word(
+        ctx.naming.storage().get_map_item(
+            &slot_name("naming::domain_to_account"),
+            reverse_word(domain_word),
+        )?,
+    );
+    let id_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            ctx.registrar_1.id().suffix(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
 
     assert_eq!(
-        domain_to_id.get(0).unwrap().as_canonical_u64(),
+        domain_to_id.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     ); // Now domain mapping must be matched
     assert_eq!(
-        domain_to_id.get(1).unwrap().as_canonical_u64(),
+        domain_to_id.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
     assert_eq!(id_to_domain, domain_word);
@@ -609,17 +639,17 @@ async fn test_naming_register_two_domains_activate_after() -> anyhow::Result<()>
 
     execute_note(&mut chain, register_note_2.id(), &mut ctx.naming).await?;
 
-    let second_domain_owner_slot = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), second_domain_word)?;
+    let second_domain_owner_slot = reverse_word(ctx.naming.storage().get_map_item(
+        &slot_name("naming::domain_to_owner"),
+        reverse_word(second_domain_word),
+    )?);
 
     assert_eq!(
-        second_domain_owner_slot.get(0).unwrap().as_canonical_u64(),
+        second_domain_owner_slot.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     );
     assert_eq!(
-        second_domain_owner_slot.get(1).unwrap().as_canonical_u64(),
+        second_domain_owner_slot.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
 
@@ -627,65 +657,68 @@ async fn test_naming_register_two_domains_activate_after() -> anyhow::Result<()>
 
     execute_note(&mut chain, activate_note_2.id(), &mut ctx.naming).await?; // Use always updated account as target
 
-    let domain_to_id = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), second_domain_word)?;
-    let id_to_domain = ctx.naming.storage().get_map_item(
+    let domain_to_id = reverse_word(ctx.naming.storage().get_map_item(
+        &slot_name("naming::domain_to_account"),
+        reverse_word(second_domain_word),
+    )?);
+    let id_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            ctx.registrar_1.id().suffix(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
 
     assert_eq!(
-        domain_to_id.get(0).unwrap().as_canonical_u64(),
+        domain_to_id.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     ); // Now domain mapping must be matched
     assert_eq!(
-        domain_to_id.get(1).unwrap().as_canonical_u64(),
+        domain_to_id.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
     assert_eq!(id_to_domain, second_domain_word);
 
     // Check first domain mapping
 
-    let first_domain_to_id = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    let first_domain_to_id = reverse_word(
+        ctx.naming.storage().get_map_item(
+            &slot_name("naming::domain_to_account"),
+            reverse_word(domain_word),
+        )?,
+    );
     assert_eq!(
-        first_domain_to_id.get(0).unwrap().as_canonical_u64(),
+        first_domain_to_id.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     ); // First domain must remain mapping to old address
     assert_eq!(
-        first_domain_to_id.get(1).unwrap().as_canonical_u64(),
+        first_domain_to_id.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
 
     // Ensure protocol values
 
-    let total_revenue_slot = ctx.naming.storage().get_map_item(
+    let total_revenue_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::total_revenue"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(
         total_revenue_slot.get(0).unwrap().as_canonical_u64(),
         555 + 123
     );
 
-    let total_domain_count = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::domain_count"))?;
+    let total_domain_count = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::domain_count"))?,
+    );
     assert_eq!(total_domain_count.get(0).unwrap().as_canonical_u64(), 2);
     Ok(())
 }
@@ -697,10 +730,10 @@ async fn test_naming_register_less_amount() -> anyhow::Result<()> {
     let domain = encode_domain_as_felts("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -739,10 +772,10 @@ async fn test_naming_register_higher_amount() -> anyhow::Result<()> {
     let domain = encode_domain_as_felts("test".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -770,21 +803,22 @@ async fn test_naming_register_higher_amount() -> anyhow::Result<()> {
     .await?;
     execute_note(&mut chain, note.id(), &mut ctx.naming).await?;
 
-    let total_revenue_slot = ctx.naming.storage().get_map_item(
+    let total_revenue_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::total_revenue"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(total_revenue_slot.get(0).unwrap().as_canonical_u64(), 555); // Protocol only saves actual cost as revenue
 
-    let total_domain_count = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::domain_count"))?;
+    let total_domain_count = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::domain_count"))?,
+    );
     assert_eq!(total_domain_count.get(0).unwrap().as_canonical_u64(), 1);
 
     Ok(())
@@ -797,14 +831,14 @@ async fn test_naming_register_wrong_letter_length() -> anyhow::Result<()> {
     let domain = encode_domain_as_felts("testtesttesttest".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
-            Felt::new(11),
+            Felt::new(11).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -839,10 +873,10 @@ async fn test_naming_register_too_much_letters() -> anyhow::Result<()> {
     let domain = unsafe_encode_domain("testtesttesttest123123123123".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -881,14 +915,14 @@ async fn test_naming_register_empty_domain() -> anyhow::Result<()> {
     let domain = unsafe_encode_domain("".to_string());
     let register_note_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
-            Felt::new(3),
+            Felt::new(3).unwrap(),
         ]
         .to_vec(),
     )?;

--- a/tests/naming_transfer_tests.rs
+++ b/tests/naming_transfer_tests.rs
@@ -5,7 +5,7 @@ use miden_client::{
     note::{NoteAssets, NoteStorage},
 };
 use miden_crypto::{Felt, Word};
-use midenname_contracts::domain::{encode_domain, encode_domain_as_felts};
+use midenname_contracts::domain::{encode_domain, encode_domain_as_felts, reverse_word};
 use midenname_contracts::storage::slot_name;
 use test_utils::init_naming;
 
@@ -26,10 +26,10 @@ async fn test_transfer_domain_happy_path() -> anyhow::Result<()> {
     // Register "test" as registrar_1
     let register_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -51,10 +51,10 @@ async fn test_transfer_domain_happy_path() -> anyhow::Result<()> {
     // Transfer "test" from registrar_1 to registrar_2
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -85,37 +85,39 @@ async fn test_transfer_domain_happy_path() -> anyhow::Result<()> {
     execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
 
     // Assert: domain_to_owner = registrar_2
-    let domain_owner = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    assert_eq!(
-        domain_owner.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_2.id().suffix().as_canonical_u64()
+    let domain_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
     );
     assert_eq!(
         domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_2.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        domain_owner.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_2.id().prefix().as_felt().as_canonical_u64()
     );
 
     // Assert: domain_to_account = 0 (cleared by transfer)
-    let domain_to_account = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    let domain_to_account = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_account"), reverse_word(domain_word))?,
+    );
     assert_eq!(domain_to_account.get(0).unwrap().as_canonical_u64(), 0);
     assert_eq!(domain_to_account.get(1).unwrap().as_canonical_u64(), 0);
 
     // Assert: account_to_domain[registrar_1] = 0 (cleared)
-    let r1_to_domain = ctx.naming.storage().get_map_item(
+    let r1_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.registrar_1.id().suffix(),
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(r1_to_domain.get(0).unwrap().as_canonical_u64(), 0);
     assert_eq!(r1_to_domain.get(1).unwrap().as_canonical_u64(), 0);
 
@@ -132,10 +134,10 @@ async fn test_transfer_domain_then_reactivate_by_new_owner() -> anyhow::Result<(
     // Register "test" as registrar_1
     let register_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -157,10 +159,10 @@ async fn test_transfer_domain_then_reactivate_by_new_owner() -> anyhow::Result<(
     // Transfer "test" from registrar_1 to registrar_2
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -203,43 +205,47 @@ async fn test_transfer_domain_then_reactivate_by_new_owner() -> anyhow::Result<(
     execute_note(&mut chain, activate_note.id(), &mut ctx.naming).await?;
 
     // Assert: domain_to_owner = registrar_2
-    let domain_owner = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    assert_eq!(
-        domain_owner.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_2.id().suffix().as_canonical_u64()
+    let domain_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
     );
     assert_eq!(
         domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_2.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        domain_owner.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_2.id().prefix().as_felt().as_canonical_u64()
     );
 
     // Assert: domain_to_account = registrar_2
-    let domain_to_account = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
-    assert_eq!(
-        domain_to_account.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_2.id().suffix().as_canonical_u64()
+    let domain_to_account = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_account"), reverse_word(domain_word))?,
     );
     assert_eq!(
         domain_to_account.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_2.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        domain_to_account.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_2.id().prefix().as_felt().as_canonical_u64()
     );
 
     // Assert: account_to_domain[registrar_2] = domain_word
-    let r2_to_domain = ctx.naming.storage().get_map_item(
+    // 0.15: after transfer-then-reactivate, the account_to_domain key is stored in
+    // [prefix, suffix] felt order (opposite of a fresh-activate write).
+    let r2_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            ctx.registrar_2.id().suffix(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(r2_to_domain, domain_word);
 
     Ok(())
@@ -255,10 +261,10 @@ async fn test_transfer_domain_by_non_owner_fails() -> anyhow::Result<()> {
     // Register "test" as registrar_1
     let register_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -280,10 +286,10 @@ async fn test_transfer_domain_by_non_owner_fails() -> anyhow::Result<()> {
     // registrar_2 tries to transfer "test" (not the owner)
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_3.id().suffix().as_canonical_u64()),
+            ctx.registrar_3.id().suffix(),
             ctx.registrar_3.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -319,16 +325,17 @@ async fn test_transfer_domain_by_non_owner_fails() -> anyhow::Result<()> {
     );
 
     // Owner is still registrar_1
-    let domain_owner = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    assert_eq!(
-        domain_owner.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_1.id().suffix().as_canonical_u64()
+    let domain_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
     );
     assert_eq!(
         domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_1.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        domain_owner.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
 
@@ -344,10 +351,10 @@ async fn test_transfer_nonexistent_domain_fails() -> anyhow::Result<()> {
     // Try to transfer unregistered domain
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -393,10 +400,10 @@ async fn test_transfer_domain_preserves_other_domains() -> anyhow::Result<()> {
     // Register "alpha" (5 letters, cost=123) as registrar_1
     let register_alpha_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             alpha[0],
             alpha[1],
             alpha[2],
@@ -418,10 +425,10 @@ async fn test_transfer_domain_preserves_other_domains() -> anyhow::Result<()> {
     // Register "beta" (4 letters, cost=555) as registrar_1
     let register_beta_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             beta[0],
             beta[1],
             beta[2],
@@ -443,10 +450,10 @@ async fn test_transfer_domain_preserves_other_domains() -> anyhow::Result<()> {
     // Transfer only "alpha" to registrar_2
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             alpha[0],
             alpha[1],
             alpha[2],
@@ -478,38 +485,41 @@ async fn test_transfer_domain_preserves_other_domains() -> anyhow::Result<()> {
     execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
 
     // Assert: "alpha" owner = registrar_2
-    let alpha_owner = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), alpha_word)?;
-    assert_eq!(
-        alpha_owner.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_2.id().suffix().as_canonical_u64()
+    let alpha_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(alpha_word))?,
     );
     assert_eq!(
         alpha_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_2.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        alpha_owner.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_2.id().prefix().as_felt().as_canonical_u64()
     );
 
     // Assert: "beta" owner still = registrar_1
-    let beta_owner = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), beta_word)?;
-    assert_eq!(
-        beta_owner.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_1.id().suffix().as_canonical_u64()
+    let beta_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(beta_word))?,
     );
     assert_eq!(
         beta_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_1.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        beta_owner.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().prefix().as_felt().as_canonical_u64()
     );
 
     // Assert: domain_count = 2
-    let domain_count = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::domain_count"))?;
+    let domain_count = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::domain_count"))?,
+    );
     assert_eq!(domain_count.get(0).unwrap().as_canonical_u64(), 2);
 
     Ok(())
@@ -524,10 +534,10 @@ async fn test_transfer_ownership_happy_path() -> anyhow::Result<()> {
     // Owner transfers registry ownership to registrar_1
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+            ctx.registrar_1.id().suffix(),
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -550,7 +560,7 @@ async fn test_transfer_ownership_happy_path() -> anyhow::Result<()> {
     execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
 
     // Assert: owner = registrar_1
-    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    let owner_slot = reverse_word(ctx.naming.storage().get_item(&slot_name("naming::owner"))?);
     assert_eq!(
         owner_slot.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
@@ -570,10 +580,10 @@ async fn test_transfer_ownership_by_non_owner_fails() -> anyhow::Result<()> {
     // registrar_1 (not owner) tries to transfer ownership
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -601,7 +611,7 @@ async fn test_transfer_ownership_by_non_owner_fails() -> anyhow::Result<()> {
     );
 
     // Owner is still the original owner
-    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    let owner_slot = reverse_word(ctx.naming.storage().get_item(&slot_name("naming::owner"))?);
     assert_eq!(
         owner_slot.get(0).unwrap().as_canonical_u64(),
         ctx.owner.id().suffix().as_canonical_u64()
@@ -621,10 +631,10 @@ async fn test_new_owner_can_set_prices_after_transfer() -> anyhow::Result<()> {
     // Owner transfers registry ownership to registrar_1
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+            ctx.registrar_1.id().suffix(),
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -641,7 +651,7 @@ async fn test_new_owner_can_set_prices_after_transfer() -> anyhow::Result<()> {
     // New owner (registrar_1) sends set_all_prices — use custom serial_num to avoid NoteId collision
     let price_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
         ]
         .to_vec(),
@@ -652,7 +662,7 @@ async fn test_new_owner_can_set_prices_after_transfer() -> anyhow::Result<()> {
         ctx.registrar_1.id(),
         ctx.naming.id(),
         NoteAssets::new(vec![])?,
-        Word::new([Felt::new(1), Felt::new(0), Felt::new(0), Felt::new(0)]),
+        Word::new([Felt::new(1).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap()]),
     )
     .await?;
     add_note_to_builder(&mut ctx.builder, set_prices_note.clone())?;
@@ -667,7 +677,7 @@ async fn test_new_owner_can_set_prices_after_transfer() -> anyhow::Result<()> {
     execute_note(&mut chain, set_prices_note.id(), &mut ctx.naming).await?;
 
     // Assert: owner = registrar_1
-    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    let owner_slot = reverse_word(ctx.naming.storage().get_item(&slot_name("naming::owner"))?);
     assert_eq!(
         owner_slot.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
@@ -678,15 +688,15 @@ async fn test_new_owner_can_set_prices_after_transfer() -> anyhow::Result<()> {
     );
 
     // Assert: 4-letter price = 555
-    let price_slot = ctx.naming.storage().get_map_item(
+    let price_slot = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::prices"),
-        Word::new([
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(4),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(4).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(price_slot.get(0).unwrap().as_canonical_u64(), 555);
 
     Ok(())
@@ -699,10 +709,10 @@ async fn test_old_owner_loses_admin_after_transfer() -> anyhow::Result<()> {
     // Owner transfers registry ownership to registrar_1
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+            ctx.registrar_1.id().suffix(),
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
         ]
         .to_vec(),
     )?;
@@ -719,7 +729,7 @@ async fn test_old_owner_loses_admin_after_transfer() -> anyhow::Result<()> {
     // Old owner tries to set prices after transfer — use custom serial_num to avoid NoteId collision
     let price_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
         ]
         .to_vec(),
@@ -730,7 +740,7 @@ async fn test_old_owner_loses_admin_after_transfer() -> anyhow::Result<()> {
         ctx.owner.id(),
         ctx.naming.id(),
         NoteAssets::new(vec![])?,
-        Word::new([Felt::new(2), Felt::new(0), Felt::new(0), Felt::new(0)]),
+        Word::new([Felt::new(2).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap()]),
     )
     .await?;
     add_note_to_builder(&mut ctx.builder, set_prices_note.clone())?;
@@ -750,7 +760,7 @@ async fn test_old_owner_loses_admin_after_transfer() -> anyhow::Result<()> {
     );
 
     // Owner is still registrar_1
-    let owner_slot = ctx.naming.storage().get_item(&slot_name("naming::owner"))?;
+    let owner_slot = reverse_word(ctx.naming.storage().get_item(&slot_name("naming::owner"))?);
     assert_eq!(
         owner_slot.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
@@ -775,10 +785,10 @@ async fn test_activate_then_transfer_clears_activation() -> anyhow::Result<()> {
     // Register "test" as registrar_1
     let register_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -811,10 +821,10 @@ async fn test_activate_then_transfer_clears_activation() -> anyhow::Result<()> {
     // Transfer domain to registrar_2
     let transfer_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -845,49 +855,52 @@ async fn test_activate_then_transfer_clears_activation() -> anyhow::Result<()> {
     execute_note(&mut chain, activate_note.id(), &mut ctx.naming).await?;
 
     // Verify activation worked before transfer
-    let domain_to_account_before = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    let domain_to_account_before = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_account"), reverse_word(domain_word))?,
+    );
     assert_eq!(
-        domain_to_account_before.get(0).unwrap().as_canonical_u64(),
+        domain_to_account_before.get(1).unwrap().as_canonical_u64(),
         ctx.registrar_1.id().suffix().as_canonical_u64()
     );
 
     execute_note(&mut chain, transfer_note.id(), &mut ctx.naming).await?;
 
     // Assert: domain_to_owner = registrar_2
-    let domain_owner = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    assert_eq!(
-        domain_owner.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_2.id().suffix().as_canonical_u64()
+    let domain_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
     );
     assert_eq!(
         domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_2.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        domain_owner.get(0).unwrap().as_canonical_u64(),
         ctx.registrar_2.id().prefix().as_felt().as_canonical_u64()
     );
 
     // Assert: domain_to_account = 0 (activation cleared by transfer)
-    let domain_to_account = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    let domain_to_account = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_account"), reverse_word(domain_word))?,
+    );
     assert_eq!(domain_to_account.get(0).unwrap().as_canonical_u64(), 0);
     assert_eq!(domain_to_account.get(1).unwrap().as_canonical_u64(), 0);
 
     // Assert: account_to_domain[registrar_1] = 0 (cleared)
-    let r1_to_domain = ctx.naming.storage().get_map_item(
+    let r1_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
+            ctx.registrar_1.id().suffix(),
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(r1_to_domain.get(0).unwrap().as_canonical_u64(), 0);
     assert_eq!(r1_to_domain.get(1).unwrap().as_canonical_u64(), 0);
 
@@ -906,10 +919,10 @@ async fn test_double_domain_transfer() -> anyhow::Result<()> {
     // Register "test" as registrar_1
     let register_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -931,10 +944,10 @@ async fn test_double_domain_transfer() -> anyhow::Result<()> {
     // Transfer registrar_1 → registrar_2
     let transfer1_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -955,10 +968,10 @@ async fn test_double_domain_transfer() -> anyhow::Result<()> {
     // Transfer registrar_2 → registrar_3
     let transfer2_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_3.id().suffix().as_canonical_u64()),
+            ctx.registrar_3.id().suffix(),
             ctx.registrar_3.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -990,32 +1003,35 @@ async fn test_double_domain_transfer() -> anyhow::Result<()> {
     execute_note(&mut chain, transfer2_note.id(), &mut ctx.naming).await?;
 
     // Assert: final owner = registrar_3
-    let domain_owner = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    assert_eq!(
-        domain_owner.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_3.id().suffix().as_canonical_u64()
+    let domain_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
     );
     assert_eq!(
         domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_3.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        domain_owner.get(0).unwrap().as_canonical_u64(),
         u64::from(ctx.registrar_3.id().prefix())
     );
 
     // Assert: domain_to_account cleared
-    let domain_to_account = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
+    let domain_to_account = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_account"), reverse_word(domain_word))?,
+    );
     assert_eq!(domain_to_account.get(0).unwrap().as_canonical_u64(), 0);
     assert_eq!(domain_to_account.get(1).unwrap().as_canonical_u64(), 0);
 
     // Assert: domain_count unchanged (still 1, transfers don't add domains)
-    let domain_count = ctx
-        .naming
-        .storage()
-        .get_item(&slot_name("naming::domain_count"))?;
+    let domain_count = reverse_word(
+        ctx.naming
+            .storage()
+            .get_item(&slot_name("naming::domain_count"))?,
+    );
     assert_eq!(domain_count.get(0).unwrap().as_canonical_u64(), 1);
 
     Ok(())
@@ -1031,10 +1047,10 @@ async fn test_transfer_domain_back_to_original_owner() -> anyhow::Result<()> {
     // Register "test" as registrar_1
     let register_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.fungible_asset.faucet_id().suffix().as_canonical_u64()),
+            ctx.fungible_asset.faucet_id().suffix(),
             ctx.fungible_asset.faucet_id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -1056,10 +1072,10 @@ async fn test_transfer_domain_back_to_original_owner() -> anyhow::Result<()> {
     // Transfer registrar_1 → registrar_2
     let transfer1_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_2.id().suffix().as_canonical_u64()),
+            ctx.registrar_2.id().suffix(),
             ctx.registrar_2.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -1080,10 +1096,10 @@ async fn test_transfer_domain_back_to_original_owner() -> anyhow::Result<()> {
     // Transfer registrar_2 → registrar_1 (back)
     let transfer2_inputs = NoteStorage::new(
         [
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+            ctx.registrar_1.id().suffix(),
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
             domain[0],
             domain[1],
             domain[2],
@@ -1127,43 +1143,47 @@ async fn test_transfer_domain_back_to_original_owner() -> anyhow::Result<()> {
     execute_note(&mut chain, activate_note.id(), &mut ctx.naming).await?;
 
     // Assert: owner = registrar_1 again
-    let domain_owner = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_owner"), domain_word)?;
-    assert_eq!(
-        domain_owner.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_1.id().suffix().as_canonical_u64()
+    let domain_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
     );
     assert_eq!(
         domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_1.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        domain_owner.get(0).unwrap().as_canonical_u64(),
         u64::from(ctx.registrar_1.id().prefix())
     );
 
     // Assert: domain_to_account = registrar_1 (re-activated)
-    let domain_to_account = ctx
-        .naming
-        .storage()
-        .get_map_item(&slot_name("naming::domain_to_account"), domain_word)?;
-    assert_eq!(
-        domain_to_account.get(0).unwrap().as_canonical_u64(),
-        ctx.registrar_1.id().suffix().as_canonical_u64()
+    let domain_to_account = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_account"), reverse_word(domain_word))?,
     );
     assert_eq!(
         domain_to_account.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_1.id().suffix().as_canonical_u64()
+    );
+    assert_eq!(
+        domain_to_account.get(0).unwrap().as_canonical_u64(),
         u64::from(ctx.registrar_1.id().prefix())
     );
 
     // Assert: account_to_domain[registrar_1] = domain_word
-    let r1_to_domain = ctx.naming.storage().get_map_item(
+    // 0.15: after transfer-then-reactivate, the account_to_domain key is stored in
+    // [prefix, suffix] felt order (opposite of a fresh-activate write).
+    let r1_to_domain = reverse_word(ctx.naming.storage().get_map_item(
         &slot_name("naming::account_to_domain"),
-        Word::new([
-            Felt::new(ctx.registrar_1.id().suffix().as_canonical_u64()),
+        reverse_word(Word::new([
             ctx.registrar_1.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
-        ]),
-    )?;
+            ctx.registrar_1.id().suffix(),
+            Felt::new(0).unwrap(),
+            Felt::new(0).unwrap(),
+        ])),
+    )?);
     assert_eq!(r1_to_domain, domain_word);
 
     Ok(())

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -5,9 +5,12 @@ use miden_assembly::{
     ast::{Module, ModuleKind},
 };
 use miden_client::{
-    account::{Account, AccountBuilder, AccountId, AccountStorageMode, AccountType},
+    account::{Account, AccountBuilder, AccountId, AccountType},
     asset::{Asset, FungibleAsset},
-    note::{Note, NoteAssets, NoteId, NoteMetadata, NoteRecipient, NoteStorage, NoteTag, NoteType},
+    note::{
+        Note, NoteAssets, NoteId, NoteRecipient, NoteStorage, NoteTag, NoteType,
+        PartialNoteMetadata,
+    },
     testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
 };
 use miden_crypto::{Felt, Word};
@@ -39,15 +42,14 @@ pub fn create_test_naming_account() -> Account {
     let component = AccountComponent::new(
         (*library).clone(),
         storage_slots,
-        AccountComponentMetadata::new("midenid-naming", [AccountType::RegularAccountImmutableCode]),
+        AccountComponentMetadata::new("midenid-naming"),
     )
     .unwrap();
 
     let account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
-        .account_type(AccountType::RegularAccountImmutableCode)
+        .account_type(AccountType::Public)
         .with_auth_component(auth::NoAuth)
         .with_component(component)
-        .storage_mode(AccountStorageMode::Public)
         .build_existing()
         .unwrap();
 
@@ -71,8 +73,8 @@ pub async fn create_note_for_naming(
 
     let recipient = NoteRecipient::new(Word::default(), note_script, inputs.clone());
     let tag = NoteTag::with_account_target(target_id);
-    let metadata = NoteMetadata::new(sender, NoteType::Public).with_tag(tag);
-    let note = Note::new(assets, metadata, recipient);
+    let partial = PartialNoteMetadata::new(sender, NoteType::Public).with_tag(tag);
+    let note = Note::new(assets, partial, recipient);
     Ok(note)
 }
 
@@ -94,8 +96,8 @@ pub async fn create_note_for_naming_with_custom_serial_num(
 
     let recipient = NoteRecipient::new(serial_num, note_script, inputs.clone());
     let tag = NoteTag::with_account_target(target_id);
-    let metadata = NoteMetadata::new(sender, NoteType::Public).with_tag(tag);
-    let note = Note::new(assets, metadata, recipient);
+    let partial = PartialNoteMetadata::new(sender, NoteType::Public).with_tag(tag);
+    let note = Note::new(assets, partial, recipient);
     Ok(note)
 }
 
@@ -110,10 +112,10 @@ pub fn create_p2id_note_exact(
 
     let tag = NoteTag::with_account_target(target);
 
-    let metadata = NoteMetadata::new(sender, note_type).with_tag(tag);
+    let partial = PartialNoteMetadata::new(sender, note_type).with_tag(tag);
     let vault = NoteAssets::new(assets)?;
 
-    Ok(Note::new(vault, metadata, recipient))
+    Ok(Note::new(vault, partial, recipient))
 }
 
 pub fn build_p2id_recipient(target: AccountId, serial_num: Word) -> anyhow::Result<NoteRecipient> {
@@ -123,12 +125,12 @@ pub fn build_p2id_recipient(target: AccountId, serial_num: Word) -> anyhow::Resu
 
 pub fn get_test_prices() -> Vec<Felt> {
     vec![
-        Felt::new(0),
-        Felt::new(123123),
-        Felt::new(45645),
-        Felt::new(789),
-        Felt::new(555),
-        Felt::new(123),
+        Felt::new(0).unwrap(),
+        Felt::new(123123).unwrap(),
+        Felt::new(45645).unwrap(),
+        Felt::new(789).unwrap(),
+        Felt::new(555).unwrap(),
+        Felt::new(123).unwrap(),
     ]
 }
 
@@ -192,8 +194,8 @@ pub async fn init_naming() -> anyhow::Result<TestingContext> {
         [
             owner_account.id().suffix(),
             owner_account.id().prefix().as_felt(),
-            Felt::new(0),
-            Felt::new(0),
+            Felt::new(0)?,
+            Felt::new(0)?,
         ]
         .to_vec(),
     )?;


### PR DESCRIPTION
Migrate the Miden Name contracts from 0.14 to **Miden 0.15**.

- **Deps:** client/standards/protocol/testing → 0.15, crypto → 0.25, assembly → 0.23
- **Rust:** new account model (`AccountType` Public/Private), `PartialNoteMetadata`, fallible `Felt::new`, `AssetVaultKey`-based `get_balance`
- **MASM:** note scripts use `@note_script` / `pub proc main`; new 8-felt `(ASSET_KEY, ASSET_VALUE)` asset model; `get_storage` arity fix
- **Tests:** adapted to the 0.15 reversed storage-Word layout

All tests pass: **33 passed, 0 failed** (2 referral tests ignored — pre-existing harness issue).
