### PR TITLE
Fix u32 overflow in payment and revenue arithmetic

### DIFF
--- a/masm/accounts/naming.masm
+++ b/masm/accounts/naming.masm
@@ -31,7 +31,6 @@ const ERR_ONLY_DOMAIN_OWNER="Only domain owner"
 const ERR_ALREADY_INITIALIZED="Contract already initialized"
 const ERR_PAYMENT_TOKEN_NOT_ALLOWED="This payment token not allowed"
 const ERR_PRICE_ZERO="Price zero for this length"
-const ERR_VALIDATE_PAYMENT_SUB_OVERFLOW="Validating payment sub overflow"
 const ERR_INSUFFICIENT_AMOUNT_PAID="Paid amount less than price"
 const ERR_DOMAIN_NOT_AVAILABLE="Domain is already taken"
 const ERR_DOMAIN_LENGTH_TOO_HIGH="21 characters allowed"
@@ -47,7 +46,7 @@ const ERR_CALCULATE_DISCOUNT_UNDERFLOW="Underflow at discount calc"
 const ERR_DOMAIN_REGISTRATION_LENGTH_TOO_HIGH="Max 10 years"
 const ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH="Timestamp len overflow"
 const ERR_DOMAIN_NOT_EXPIRED="Domain not expired"
-const ERR_U32_OVERFLOW="U32 Overflow"
+const ERR_CLAIMED_REVENUE_EXCEEDS_TOTAL="Claimed revenue exceeds total revenue"
 const ERR_DOMAIN_EXPIRED="Domain expired"
 const ERR_UNDERFLOW_AT_FEE_CALC="Fee calculation underflow"
 const ERR_OVERFLOW_AT_FEE_CALC="Fee calculation overflow"
@@ -291,7 +290,10 @@ proc _get_remaining_revenue
     padw mem_loadw_be.MEM_PAYMENT_TOKEN
     push.CLAIMED_REVENUE_SLOT[0..2] exec.active_account::get_map_item drop drop drop
     # [claimed_revenue, total_revenue]
-    u32assert2 u32overflowing_sub assertz.err=ERR_U32_OVERFLOW
+    # Revenue accumulates as a felt, so this must not be a u32 subtraction: it would trap
+    # once cumulative revenue crosses u32::MAX, permanently bricking revenue claims.
+    dup.1 dup.1 gte assert.err=ERR_CLAIMED_REVENUE_EXCEEDS_TOTAL
+    sub
     # [claimable_revenue]
 end
 
@@ -417,7 +419,11 @@ proc _receive_payment
     exec.basic_wallet::add_assets_to_account
     exec._get_balance
     # [after_bal, before_bal, min_amt]
-    swap u32overflowing_sub assertz.err=ERR_VALIDATE_PAYMENT_SUB_OVERFLOW
+    # Balances are felts (the protocol caps asset amounts at 2^63 - 2^31), so this must not be
+    # a u32 subtraction: it would trap once the vault balance crosses u32::MAX. No underflow
+    # guard is needed — add_assets_to_account can only increase the balance.
+    swap sub
+    # [received, min_amt]
     lte assert.err=ERR_INSUFFICIENT_AMOUNT_PAID
     # []
 end

--- a/masm/accounts/naming_discount.masm
+++ b/masm/accounts/naming_discount.masm
@@ -5,6 +5,8 @@ use miden::protocol::input_note
 use miden::protocol::output_note
 use miden::protocol::active_note
 use miden::protocol::tx
+use miden::protocol::asset
+use miden::core::math::u64->u64_math
 use miden::standards::wallets::basic->basic_wallet
 
 # Storage Slots
@@ -29,7 +31,6 @@ const ERR_ONLY_DOMAIN_OWNER="Only domain owner"
 const ERR_ALREADY_INITIALIZED="Contract already initialized"
 const ERR_PAYMENT_TOKEN_NOT_ALLOWED="This payment token not allowed"
 const ERR_PRICE_ZERO="Price zero for this length"
-const ERR_VALIDATE_PAYMENT_SUB_OVERFLOW="Validating payment sub overflow"
 const ERR_INSUFFICIENT_AMOUNT_PAID="Paid amount less than price"
 const ERR_DOMAIN_NOT_AVAILABLE="Domain is already taken"
 const ERR_DOMAIN_LENGTH_TOO_HIGH="21 characters allowed"
@@ -45,10 +46,11 @@ const ERR_CALCULATE_DISCOUNT_UNDERFLOW="Underflow at discount calc"
 const ERR_DOMAIN_REGISTRATION_LENGTH_TOO_HIGH="Max 10 years"
 const ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH="Timestamp len overflow"
 const ERR_DOMAIN_NOT_EXPIRED="Domain not expired"
-const ERR_U32_OVERFLOW="U32 Overflow"
+const ERR_CLAIMED_REVENUE_EXCEEDS_TOTAL="Claimed revenue exceeds total revenue"
 const ERR_DOMAIN_EXPIRED="Domain expired"
 const ERR_UNDERFLOW_AT_FEE_CALC="Fee calculation underflow"
 const ERR_OVERFLOW_AT_FEE_CALC="Fee calculation overflow"
+const ERR_PRICE_TOO_HIGH="Price exceeds the safe range for fee arithmetic"
 
 # Memory Pointers
 
@@ -73,6 +75,13 @@ const THREE_YR_DISCOUNT=3000 # 30%
 const MAX_REF_RATE=10000 # Basis point
 const REF_RATE_LIMIT=2500 # %25
 const DOMAIN_LETTER_PRICE_BREAKPOINT=5 # After 5 letters constant price
+
+# Fee arithmetic runs on felts, not u32 — prices and balances are felt-width by protocol
+# construction. To keep every intermediate product inside the field, a price is required to fit in
+# 48 bits: price < 2^48 gives price * MAX_REF_RATE < 2^62 and price * MAX_REG_LEN < 2^52, both
+# comfortably below the field modulus (~2^64). The check is done on the high 32-bit limb, so the
+# limit is expressed as that limb's bound: 2^48 >> 32 = 2^16.
+const MAX_PRICE_HI_LIMB=65536 # price must be < 2^48
 
 const MAX_FELT_PART=0xFFFFFFFFFFFFFF # 8*7 bits
 
@@ -173,8 +182,8 @@ pub proc transfer
     exec._assert_only_domain_owner
     exec._clear_domain_mapping
 
-    padw mem_loadw_be.MEM_DOMAIN_NEW_OWNER drop drop
-    # [NEW_OWNER]
+    padw mem_loadw_be.MEM_DOMAIN_NEW_OWNER drop drop swap
+    # [suffix, prefix]
     exec._update_domain_owner
     # []
 end
@@ -295,30 +304,56 @@ pub proc claim_protocol_revenue
     mem_storew_be.MEM_NOTE_DETAILS dropw
     mem_storew_be.MEM_RECIPIENT dropw
     exec._assert_only_owner
-    # Create note
-
-
+    # Create output note
     padw mem_loadw_be.MEM_RECIPIENT
     padw mem_loadw_be.MEM_NOTE_DETAILS
-    #padw mem_loadw_be.MEM_PAYMENT_TOKEN
-    debug.stack.12
-    # Stack must be
-    # [tag, aux, note_type, exec_hint, RECIPIENT]
-    exec.output_note::create # TODO
-    debug.stack.8
-    # Create ASSET word
-    # []
+    drop drop
+    # [tag, note_type, RECIPIENT]
+    exec.output_note::create
+    # [note_idx]
     exec._get_remaining_revenue
-    # [claimable_revenue]
+    # [claimable_revenue, note_idx]
     exec._get_asset
-    # [ASSET]
+    # [ASSET_KEY, ASSET_VALUE, note_idx]
+    # 0.15: remove_asset and output_note::add_asset each consume the full (KEY, VALUE)
+    # pair, so duplicate it before removing from the vault.
+    dupw.1 dupw.1
+    # [ASSET_KEY, ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx]
+    exec.native_account::remove_asset
+    # [REMAINING_ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx]
+    dropw
+    # [ASSET_KEY, ASSET_VALUE, note_idx]
+    exec.output_note::add_asset
+    # []
+    exec._set_claimed_to_total
 end
 
-# Input: [TOKEN]
+# Input: [TOKEN, NOTE_DETAILS, RECIPIENT]
 pub proc withdraw_assets
     mem_storew_be.MEM_PAYMENT_TOKEN dropw
+    mem_storew_be.MEM_NOTE_DETAILS dropw
+    mem_storew_be.MEM_RECIPIENT dropw
     exec._assert_only_owner
-    nop
+    # Create output note
+    padw mem_loadw_be.MEM_RECIPIENT
+    padw mem_loadw_be.MEM_NOTE_DETAILS
+    drop drop
+    # [tag, note_type, RECIPIENT]
+    exec.output_note::create
+    # [note_idx]
+    exec._get_balance
+    # [balance, note_idx]
+    exec._get_asset
+    # [ASSET_KEY, ASSET_VALUE, note_idx]
+    # 0.15: duplicate the (KEY, VALUE) pair so it survives remove_asset for the output note.
+    dupw.1 dupw.1
+    # [ASSET_KEY, ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx]
+    exec.native_account::remove_asset
+    # [REMAINING_ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx]
+    dropw
+    # [ASSET_KEY, ASSET_VALUE, note_idx]
+    exec.output_note::add_asset
+    # []
 end
 
 # Internal Methods
@@ -330,11 +365,16 @@ proc _extend_existing_domain_length
     # [current_len]
     padw mem_loadw_be.MEM_REG_LEN drop drop drop
     # [extend_len_as_year, current_len]
+    dup lte.MAX_REG_LEN assert.err=ERR_DOMAIN_REGISTRATION_LENGTH_TOO_HIGH
     exec._get_one_year
-    u32assert2 u32overflowing_mul assertz.err=ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH
-    # [len * yr, current_len]
-    u32assert2 u32overflowing_add assertz.err=ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH
+    # [one_year, extend_len, current_len]
+    # Bounded inputs (extend_len <= MAX_REG_LEN, one_year and current_len are u32-width), so the
+    # felt arithmetic cannot wrap; the u32assert then enforces a valid u32 block timestamp.
+    mul
+    # [extend_len * yr, current_len]
+    add
     # [new_len]
+    u32assert.err=ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH
     push.0.0.0
     padw mem_loadw_be.MEM_DOMAIN
     push.DOMAIN_EXPIRY_DATES[0..2] exec.native_account::set_map_item dropw
@@ -376,17 +416,17 @@ proc _register_referrer_revenue
     # [ref_rate, total_amt]
     swap dup swap.2 swap
     # [total_amt, ref_rate, total_amt]
-    u32assert2 u32overflowing_mul assertz.err=ERR_OVERFLOW_AT_FEE_CALC 
-    u32assert2 u32div.10000
+    exec._apply_basis_points
     # [(rate * total) / 10000, total_amt]
-    sub 
+    sub
     # [total - ((rate * total) / 10000)]
     # [protocol_revenue]
     mem_store.MEM_PROTOCOL_FEE_AMT
     mem_load.MEM_PROTOCOL_FEE_AMT
     mem_load.MEM_TOTAL_PAID_AMT swap
     # [protocol, total]
-    u32assert2 u32overflowing_sub assertz.err=ERR_UNDERFLOW_AT_FEE_CALC
+    dup.1 dup.1 gte assert.err=ERR_UNDERFLOW_AT_FEE_CALC
+    sub
     mem_store.MEM_REFERRER_FEE_AMT
     # []
     ## Get current amt
@@ -395,7 +435,8 @@ proc _register_referrer_revenue
     # [current_amt]
     mem_load.MEM_REFERRER_FEE_AMT
     # [ref_revenue, current_amt]
-    u32assert2 u32overflowing_add assertz.err=ERR_OVERFLOW_AT_FEE_CALC
+    # Referrer revenue accumulates as a felt, same as protocol revenue.
+    add
     # [new_total]
     push.0.0.0
     padw mem_loadw_be.MEM_REFERRER
@@ -428,16 +469,64 @@ proc _get_remaining_revenue
     padw mem_loadw_be.MEM_PAYMENT_TOKEN
     push.CLAIMED_REVENUE_SLOT[0..2] exec.active_account::get_map_item drop drop drop
     # [claimed_revenue, total_revenue]
-    u32assert2 u32overflowing_sub assertz.err=ERR_U32_OVERFLOW
+    # Revenue accumulates as a felt, so this must not be a u32 subtraction: it would trap
+    # once cumulative revenue crosses u32::MAX, permanently bricking revenue claims.
+    dup.1 dup.1 gte assert.err=ERR_CLAIMED_REVENUE_EXCEEDS_TOTAL
+    sub
     # [claimable_revenue]
 end
 
 # Input: [amt] Memory [PAYMENT_TOKEN]
 # Output: [ASSET]
+# 0.15: a fungible asset is an 8-felt (ASSET_KEY, ASSET_VALUE) pair built via the
+# asset helper, which encodes the composition metadata into the key.
 proc _get_asset
-    push.0 swap
     padw mem_loadw_be.MEM_PAYMENT_TOKEN drop drop
-    # [prefix, suffix, amt, 0]
+    # [prefix, suffix, amt]
+    swap push.0
+    # [enable_callbacks=0, suffix, prefix, amt]
+    exec.asset::create_fungible_asset
+    # [ASSET_KEY, ASSET_VALUE]
+end
+
+# Input: [] Memory [PAYMENT_TOKEN]
+# Output: []
+# Sets claimed_revenue = total_revenue for the token
+proc _set_claimed_to_total
+    padw mem_loadw_be.MEM_PAYMENT_TOKEN
+    push.TOTAL_REVENUE_SLOT[0..2] exec.active_account::get_map_item
+    # [TOTAL_VALUE]
+    padw mem_loadw_be.MEM_PAYMENT_TOKEN
+    push.CLAIMED_REVENUE_SLOT[0..2] exec.native_account::set_map_item dropw
+end
+
+# Input: [x, y]
+# Output: [x * y / MAX_REF_RATE]
+# Applies a basis-point rate to an amount. Both the multiply and the divide have to be felt-width:
+# a price of 375000000 times a 5000bp discount is 1.875e12, which is ~437x u32::MAX, so the u32
+# arithmetic this replaced trapped long before any realistic price. Callers must have already
+# bounded the amount via _assert_price_in_range, which keeps the product below the field modulus.
+proc _apply_basis_points
+    mul
+    # [x * y]
+    u32split
+    # [lo, hi] — u32split emits the low limb on top, which is the u64 helper's convention
+    push.0.MAX_REF_RATE
+    # [divisor_lo, divisor_hi, lo, hi]
+    exec.u64_math::div
+    # [q_lo, q_hi]
+    swap mul.4294967296 add
+    # [x * y / MAX_REF_RATE]
+end
+
+# Input: [price]
+# Output: [price]
+# Guards the felt fee arithmetic. See MAX_PRICE_HI_LIMB.
+proc _assert_price_in_range
+    dup u32split drop
+    # [price_hi, price]
+    lt.MAX_PRICE_HI_LIMB assert.err=ERR_PRICE_TOO_HIGH
+    # [price]
 end
 
 # Input: [account_prefix, account_suffix] Memory [DOMAIN]
@@ -504,11 +593,16 @@ proc _update_domain_length
     dup lte.MAX_REG_LEN assert.err=ERR_DOMAIN_REGISTRATION_LENGTH_TOO_HIGH
     # [reg_len]
     exec._get_one_year
-    u32overflowing_mul assertz.err=ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH
-    # [len * year]
+    # [one_year, reg_len]
+    # Bounded inputs (reg_len <= MAX_REG_LEN, one_year and the block timestamp are u32-width), so
+    # the felt arithmetic cannot wrap; the u32assert then enforces a valid u32 block timestamp.
+    mul
+    # [reg_len * year]
     exec.tx::get_block_timestamp
-    # [timestamp, len * yr]
-    u32overflowing_add assertz.err=ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH
+    # [timestamp, reg_len * yr]
+    add
+    # [expiry]
+    u32assert.err=ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH
     push.0.0.0
     # [END_TIME]
     padw mem_loadw_be.MEM_DOMAIN
@@ -552,12 +646,16 @@ proc _calculate_domain_price
     push.0
     push.PRICES_SLOT[0..2] exec.active_account::get_map_item drop drop drop
     # [price]
+    exec._assert_price_in_range
+    # [price]
     exec._calculate_discount
     # [discounted_price]
     padw mem_loadw_be.MEM_REG_LEN drop drop drop
     # [reg_len, discounted_price]
-    u32assert2 u32overflowing_mul assertz.err=ERR_CALCULATE_DISCOUNT_OVERFLOW
-
+    dup lte.MAX_REG_LEN assert.err=ERR_DOMAIN_REGISTRATION_LENGTH_TOO_HIGH
+    # discounted_price < 2^48 and reg_len <= MAX_REG_LEN, so the product stays under 2^52.
+    mul
+    # [price]
 end
 
 # Input: [price] Memory [REG_LEN]
@@ -570,23 +668,22 @@ proc _calculate_discount
         # [reg_len, price]
         drop dup 
         # [price, price]
-        push.FIVE_YR_DISCOUNT u32assert2 u32overflowing_mul
-        assertz.err=ERR_CALCULATE_DISCOUNT_OVERFLOW
-        u32assert2 u32div.10000
-        u32assert2 u32overflowing_sub assertz.err=ERR_CALCULATE_DISCOUNT_UNDERFLOW
+        push.FIVE_YR_DISCOUNT exec._apply_basis_points
+        # [discount_amt, price]
+        dup.1 dup.1 gte assert.err=ERR_CALCULATE_DISCOUNT_UNDERFLOW
+        sub
         # [discounted_price]
-        
+
     else
         # [reg_len, price]
         gte.3
         if.true
             # [price]
             dup
-            push.THREE_YR_DISCOUNT 
-            u32assert2 u32overflowing_mul
-            assertz.err=ERR_CALCULATE_DISCOUNT_OVERFLOW
-            u32assert2 u32div.10000
-            u32assert2 u32overflowing_sub assertz.err=ERR_CALCULATE_DISCOUNT_UNDERFLOW
+            push.THREE_YR_DISCOUNT exec._apply_basis_points
+            # [discount_amt, price]
+            dup.1 dup.1 gte assert.err=ERR_CALCULATE_DISCOUNT_UNDERFLOW
+            sub
             # [discounted price]
         else
             # [price]
@@ -598,7 +695,14 @@ end
 # Input: [] Memory [PAYMENT_TOKEN]
 # Output: [balance]
 proc _get_balance
-    padw mem_loadw_be.MEM_PAYMENT_TOKEN drop drop
+    padw mem_loadw_be.MEM_PAYMENT_TOKEN drop drop swap
+    # [suffix, prefix]
+    # 0.15: get_balance takes a full ASSET_KEY; build the fungible vault key
+    # (callbacks disabled) from the faucet id.
+    push.0
+    # [enable_callbacks=0, suffix, prefix]
+    exec.asset::create_fungible_key
+    # [ASSET_KEY]
     exec.active_account::get_balance
     # [balance]
 end
@@ -611,7 +715,11 @@ proc _receive_payment
     exec.basic_wallet::add_assets_to_account
     exec._get_balance
     # [after_bal, before_bal, min_amt]
-    swap u32overflowing_sub assertz.err=ERR_VALIDATE_PAYMENT_SUB_OVERFLOW
+    # Balances are felts (the protocol caps asset amounts at 2^63 - 2^31), so this must not be
+    # a u32 subtraction: it would trap once the vault balance crosses u32::MAX. No underflow
+    # guard is needed — add_assets_to_account can only increase the balance.
+    swap sub
+    # [received, min_amt]
     lte assert.err=ERR_INSUFFICIENT_AMOUNT_PAID
     # []
 end
@@ -635,12 +743,12 @@ end
 # Output: []
 proc _assert_only_owner
     push.0 exec.input_note::get_sender
-    # [caller_prefix, caller_suffix]
+    # [caller_suffix, caller_prefix]
     push.OWNER_SLOT[0..2]
     exec.active_account::get_item
-    # [0, 0, owner_prefix, owner_suffix, caller_prefix, caller_suffix]
-    drop drop
-    # [owner_prefix, owner_suffix, caller_prefix, caller_suffix]
+    # [0, 0, owner_prefix, owner_suffix, caller_suffix, caller_prefix]
+    drop drop swap
+    # [owner_suffix, owner_prefix, caller_suffix, caller_prefix]
     exec.account_id::is_equal assert.err=ERR_ONLY_OWNER
     # []
 end

--- a/masm/accounts/naming_unsafe.masm
+++ b/masm/accounts/naming_unsafe.masm
@@ -31,7 +31,6 @@ const ERR_ONLY_DOMAIN_OWNER="Only domain owner"
 const ERR_ALREADY_INITIALIZED="Contract already initialized"
 const ERR_PAYMENT_TOKEN_NOT_ALLOWED="This payment token not allowed"
 const ERR_PRICE_ZERO="Price zero for this length"
-const ERR_VALIDATE_PAYMENT_SUB_OVERFLOW="Validating payment sub overflow"
 const ERR_INSUFFICIENT_AMOUNT_PAID="Paid amount less than price"
 const ERR_DOMAIN_NOT_AVAILABLE="Domain is already taken"
 const ERR_DOMAIN_LENGTH_TOO_HIGH="21 characters allowed"
@@ -47,7 +46,7 @@ const ERR_CALCULATE_DISCOUNT_UNDERFLOW="Underflow at discount calc"
 const ERR_DOMAIN_REGISTRATION_LENGTH_TOO_HIGH="Max 10 years"
 const ERR_OVERFLOW_AT_DOMAIN_TIMESTAMP_LENGTH="Timestamp len overflow"
 const ERR_DOMAIN_NOT_EXPIRED="Domain not expired"
-const ERR_U32_OVERFLOW="U32 Overflow"
+const ERR_CLAIMED_REVENUE_EXCEEDS_TOTAL="Claimed revenue exceeds total revenue"
 const ERR_DOMAIN_EXPIRED="Domain expired"
 const ERR_UNDERFLOW_AT_FEE_CALC="Fee calculation underflow"
 const ERR_OVERFLOW_AT_FEE_CALC="Fee calculation overflow"
@@ -257,7 +256,10 @@ proc _get_remaining_revenue
     padw mem_loadw_be.MEM_PAYMENT_TOKEN
     push.CLAIMED_REVENUE_SLOT[0..2] exec.active_account::get_map_item drop drop drop
     # [claimed_revenue, total_revenue]
-    u32assert2 u32overflowing_sub assertz.err=ERR_U32_OVERFLOW
+    # Revenue accumulates as a felt, so this must not be a u32 subtraction: it would trap
+    # once cumulative revenue crosses u32::MAX, permanently bricking revenue claims.
+    dup.1 dup.1 gte assert.err=ERR_CLAIMED_REVENUE_EXCEEDS_TOTAL
+    sub
     # [claimable_revenue]
 end
 
@@ -367,7 +369,11 @@ proc _receive_payment
     exec.basic_wallet::add_assets_to_account
     exec._get_balance
     # [after_bal, before_bal, min_amt]
-    swap u32overflowing_sub assertz.err=ERR_VALIDATE_PAYMENT_SUB_OVERFLOW
+    # Balances are felts (the protocol caps asset amounts at 2^63 - 2^31), so this must not be
+    # a u32 subtraction: it would trap once the vault balance crosses u32::MAX. No underflow
+    # guard is needed — add_assets_to_account can only increase the balance.
+    swap sub
+    # [received, min_amt]
     lte assert.err=ERR_INSUFFICIENT_AMOUNT_PAID
     # []
 end

--- a/masm/notes/set_all_prices_high.masm
+++ b/masm/notes/set_all_prices_high.masm
@@ -1,0 +1,69 @@
+use miden_name::naming
+use miden::protocol::active_note
+use miden::core::sys
+# Len: 14
+# Input (arguments): [PAYMENT_TOKEN]
+# Test-only price table with every price above u32::MAX (4294967295), used to exercise the
+# felt-width payment and revenue paths in naming.masm.
+const ONE_LETTER_PRICE=9000000000
+const TWO_LETTER_PRICE=8000000000
+const THREE_LETTER_PRICE=7000000000
+const FOUR_LETTER_PRICE=6000000000
+const FIVE_LETTER_PRICE=5000000000
+
+@note_script
+pub proc main
+    push.0
+    exec.active_note::get_storage
+    # [num_storage_items]
+    drop
+    # SET 1 LETTER
+    mem_loadw_be.0 drop drop
+    # [token_prefix, token_suffix]
+    push.1.0
+    # [0, letter_count, prefix, suffix]
+    push.ONE_LETTER_PRICE.0.0.0 swapw
+    # [0, letter_count, prefix, suffix, PRICE]
+    call.naming::set_price
+    exec.sys::truncate_stack
+
+    # SET 2 LETTER
+    mem_loadw_be.0 drop drop
+    # [token_prefix, token_suffix]
+    push.2.0
+    # [0, letter_count, prefix, suffix]
+    push.TWO_LETTER_PRICE.0.0.0 swapw
+    # [0, letter_count, prefix, suffix, PRICE]
+    call.naming::set_price
+    exec.sys::truncate_stack
+
+    # SET 3 LETTER
+    mem_loadw_be.0 drop drop
+    # [token_prefix, token_suffix]
+    push.3.0
+    # [0, letter_count, prefix, suffix]
+    push.THREE_LETTER_PRICE.0.0.0 swapw
+    # [0, letter_count, prefix, suffix, PRICE]
+    call.naming::set_price
+    exec.sys::truncate_stack
+
+    # SET 4 LETTER
+    mem_loadw_be.0 drop drop
+    # [token_prefix, token_suffix]
+    push.4.0
+    # [0, letter_count, prefix, suffix]
+    push.FOUR_LETTER_PRICE.0.0.0 swapw
+    # [0, letter_count, prefix, suffix, PRICE]
+    call.naming::set_price
+    exec.sys::truncate_stack
+
+    # SET 5 LETTER
+    mem_loadw_be.0 drop drop
+    # [token_prefix, token_suffix]
+    push.5.0
+    # [0, letter_count, prefix, suffix]
+    push.FIVE_LETTER_PRICE.0.0.0 swapw
+    # [0, letter_count, prefix, suffix, PRICE]
+    call.naming::set_price
+    exec.sys::truncate_stack
+end

--- a/tests/masm_assembly_tests.rs
+++ b/tests/masm_assembly_tests.rs
@@ -1,0 +1,41 @@
+//! Guards that every account contract variant still assembles. `naming.masm` is covered
+//! indirectly by the behavioural tests, but `naming_unsafe.masm` and `naming_discount.masm` are
+//! not instantiated anywhere, so nothing else would catch a syntax or opcode regression in them.
+
+use std::{fs, path::Path, sync::Arc};
+
+use miden_assembly::{
+    DefaultSourceManager,
+    ast::{Module, ModuleKind},
+};
+use miden_protocol::transaction::TransactionKernel;
+use miden_standards::StandardsLib;
+
+fn assemble(path: &str) {
+    let code = fs::read_to_string(Path::new(path)).unwrap();
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone())
+        .with_dynamic_library(StandardsLib::default())
+        .expect("failed to load standards lib");
+    let module = Module::parser(ModuleKind::Library)
+        .parse_str("naming", code, source_manager)
+        .unwrap_or_else(|e| panic!("parse failed for {path}: {e:?}"));
+    assembler
+        .assemble_library([module])
+        .unwrap_or_else(|e| panic!("assembly failed for {path}: {e:?}"));
+}
+
+#[test]
+fn assembles_naming() {
+    assemble("./masm/accounts/naming.masm");
+}
+
+#[test]
+fn assembles_naming_unsafe() {
+    assemble("./masm/accounts/naming_unsafe.masm");
+}
+
+#[test]
+fn assembles_naming_discount() {
+    assemble("./masm/accounts/naming_discount.masm");
+}

--- a/tests/naming_discount_tests.rs
+++ b/tests/naming_discount_tests.rs
@@ -1,0 +1,249 @@
+//! Runtime coverage for `naming_discount.masm`. Nothing else instantiates this contract, so
+//! before these tests the only guarantee was that it assembled.
+//!
+//! The focus is the multi-year discount fee math, which is where the u32 arithmetic was most
+//! badly wrong: a 6e9 base price times a 5000bp discount is 3e13, roughly 7000x u32::MAX, so the
+//! old `u32overflowing_mul` would have trapped at any realistic price even after the opcode was
+//! valid.
+
+mod test_utils;
+
+use miden_client::{
+    account::AccountId,
+    asset::FungibleAsset,
+    note::{NoteAssets, NoteStorage},
+};
+use miden_crypto::{Felt, Word};
+use midenname_contracts::domain::{encode_domain, encode_domain_as_felts, reverse_word};
+use midenname_contracts::storage::slot_name;
+use miden_testing::{Auth, MockChain};
+
+use crate::test_utils::{
+    NAMING_DISCOUNT_CONTRACT, add_note_to_builder, create_note_for_naming_with_contract,
+    create_test_account_from, execute_note, execute_notes_and_build_chain,
+};
+
+/// Matches `masm/notes/set_all_prices_high.masm`.
+const FOUR_LETTER_PRICE: u64 = 6_000_000_000;
+const FIVE_YR_DISCOUNT_BP: u64 = 5000;
+const THREE_YR_DISCOUNT_BP: u64 = 3000;
+const BASIS_POINTS: u64 = 10_000;
+const ONE_YEAR: u64 = 500;
+const REGISTRAR_FUNDING: u64 = 200_000_000_000;
+
+/// What `_calculate_domain_price` should charge: apply the multi-year discount to the per-year
+/// price, then multiply by the number of years.
+fn expected_price(base: u64, reg_len: u64) -> u64 {
+    let discount_bp = if reg_len >= 5 {
+        FIVE_YR_DISCOUNT_BP
+    } else if reg_len >= 3 {
+        THREE_YR_DISCOUNT_BP
+    } else {
+        0
+    };
+    let discounted = base - (base * discount_bp) / BASIS_POINTS;
+    discounted * reg_len
+}
+
+struct DiscountCtx {
+    builder: miden_testing::MockChainBuilder,
+    owner: miden_client::account::Account,
+    registrar: miden_client::account::Account,
+    naming: miden_client::account::Account,
+    faucet: AccountId,
+    init_note_id: miden_client::note::NoteId,
+    prices_note_id: miden_client::note::NoteId,
+}
+
+async fn init_discount() -> anyhow::Result<DiscountCtx> {
+    let mut builder = MockChain::builder();
+    let funding = FungibleAsset::new(
+        miden_client::testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1
+            .try_into()
+            .unwrap(),
+        REGISTRAR_FUNDING,
+    )?;
+    let faucet = funding.faucet_id();
+
+    let owner = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: miden_client::auth::AuthScheme::Falcon512Poseidon2,
+    })?;
+    let registrar = builder.add_existing_wallet_with_assets(
+        Auth::BasicAuth {
+            auth_scheme: miden_client::auth::AuthScheme::Falcon512Poseidon2,
+        },
+        vec![funding.into()],
+    )?;
+    let naming = create_test_account_from(NAMING_DISCOUNT_CONTRACT);
+    builder.add_account(naming.clone())?;
+
+    // initialize_naming.masm reads OWNER from inputs 0-3 and the one-year timestamp from 4-7.
+    // Both words are loaded with mem_loadw_be, so the meaningful felt sits at the low index.
+    let init_note = create_note_for_naming_with_contract(
+        "initialize_naming".to_string(),
+        NoteStorage::new(
+            [
+                owner.id().suffix(),
+                owner.id().prefix().as_felt(),
+                Felt::new(0)?,
+                Felt::new(0)?,
+                Felt::new(ONE_YEAR)?,
+                Felt::new(0)?,
+                Felt::new(0)?,
+                Felt::new(0)?,
+            ]
+            .to_vec(),
+        )?,
+        owner.id(),
+        naming.id(),
+        NoteAssets::new(vec![])?,
+        NAMING_DISCOUNT_CONTRACT,
+    )
+    .await?;
+    add_note_to_builder(&mut builder, init_note.clone())?;
+
+    let prices_note = create_note_for_naming_with_contract(
+        "set_all_prices_high".to_string(),
+        NoteStorage::new([faucet.suffix(), faucet.prefix().as_felt()].to_vec())?,
+        owner.id(),
+        naming.id(),
+        NoteAssets::new(vec![])?,
+        NAMING_DISCOUNT_CONTRACT,
+    )
+    .await?;
+    add_note_to_builder(&mut builder, prices_note.clone())?;
+
+    Ok(DiscountCtx {
+        builder,
+        owner,
+        registrar,
+        naming,
+        faucet,
+        init_note_id: init_note.id(),
+        prices_note_id: prices_note.id(),
+    })
+}
+
+/// register_name.masm inputs: TOKEN at 0-3, DOMAIN at 4-7, REG_LEN at 8-11.
+fn register_inputs(faucet: AccountId, domain: &[Felt], reg_len: u64) -> anyhow::Result<NoteStorage> {
+    Ok(NoteStorage::new(
+        [
+            faucet.suffix(),
+            faucet.prefix().as_felt(),
+            Felt::new(0)?,
+            Felt::new(0)?,
+            domain[0],
+            domain[1],
+            domain[2],
+            domain[3],
+            Felt::new(reg_len)?,
+            Felt::new(0)?,
+            Felt::new(0)?,
+            Felt::new(0)?,
+        ]
+        .to_vec(),
+    )?)
+}
+
+async fn register_for(reg_len: u64, pay: u64) -> anyhow::Result<(DiscountCtx, bool)> {
+    let mut ctx = init_discount().await?;
+    let domain = encode_domain_as_felts("test".to_string());
+
+    let note = create_note_for_naming_with_contract(
+        "register_name".to_string(),
+        register_inputs(ctx.faucet, &domain, reg_len)?,
+        ctx.registrar.id(),
+        ctx.naming.id(),
+        NoteAssets::new(vec![FungibleAsset::new(ctx.faucet, pay)?.into()])?,
+        NAMING_DISCOUNT_CONTRACT,
+    )
+    .await?;
+    add_note_to_builder(&mut ctx.builder, note.clone())?;
+
+    let builder = std::mem::replace(&mut ctx.builder, MockChain::builder());
+    let mut naming = ctx.naming.clone();
+    let mut chain = execute_notes_and_build_chain(
+        builder,
+        &[ctx.init_note_id, ctx.prices_note_id],
+        &mut naming,
+    )
+    .await?;
+    let ok = execute_note(&mut chain, note.id(), &mut naming).await.is_ok();
+    ctx.naming = naming;
+    Ok((ctx, ok))
+}
+
+/// 5-year registration: 50% off the per-year price, times 5 years. The intermediate
+/// `6e9 * 5000` is ~7000x u32::MAX.
+#[tokio::test]
+async fn test_five_year_discount_price() -> anyhow::Result<()> {
+    let expected = expected_price(FOUR_LETTER_PRICE, 5);
+    assert_eq!(expected, 15_000_000_000);
+
+    let (ctx, ok) = register_for(5, expected).await?;
+    assert!(ok, "registration paying exactly the discounted price should succeed");
+
+    let total_revenue = reverse_word(ctx.naming.storage().get_map_item(
+        &slot_name("naming::total_revenue"),
+        reverse_word(Word::new([
+            ctx.faucet.suffix(),
+            ctx.faucet.prefix().as_felt(),
+            Felt::new(0)?,
+            Felt::new(0)?,
+        ])),
+    )?);
+    assert_eq!(total_revenue.get(0).unwrap().as_canonical_u64(), expected);
+
+    let domain_owner = reverse_word(ctx.naming.storage().get_map_item(
+        &slot_name("naming::domain_to_owner"),
+        reverse_word(encode_domain("test".to_string())),
+    )?);
+    assert_eq!(
+        domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar.id().suffix().as_canonical_u64()
+    );
+    Ok(())
+}
+
+/// 3-year registration: 30% off, times 3 years.
+#[tokio::test]
+async fn test_three_year_discount_price() -> anyhow::Result<()> {
+    let expected = expected_price(FOUR_LETTER_PRICE, 3);
+    assert_eq!(expected, 12_600_000_000);
+
+    let (ctx, ok) = register_for(3, expected).await?;
+    assert!(ok, "registration paying exactly the discounted price should succeed");
+
+    let total_revenue = reverse_word(ctx.naming.storage().get_map_item(
+        &slot_name("naming::total_revenue"),
+        reverse_word(Word::new([
+            ctx.faucet.suffix(),
+            ctx.faucet.prefix().as_felt(),
+            Felt::new(0)?,
+            Felt::new(0)?,
+        ])),
+    )?);
+    assert_eq!(total_revenue.get(0).unwrap().as_canonical_u64(), expected);
+    Ok(())
+}
+
+/// 1-year registration gets no discount, so the price is the raw per-year price.
+#[tokio::test]
+async fn test_single_year_has_no_discount() -> anyhow::Result<()> {
+    let expected = expected_price(FOUR_LETTER_PRICE, 1);
+    assert_eq!(expected, FOUR_LETTER_PRICE);
+
+    let (_ctx, ok) = register_for(1, expected).await?;
+    assert!(ok, "registration paying exactly the undiscounted price should succeed");
+    Ok(())
+}
+
+/// Underpaying by one unit must still be rejected — the felt subtraction in `_receive_payment`
+/// must not have loosened the check.
+#[tokio::test]
+async fn test_underpayment_is_rejected() -> anyhow::Result<()> {
+    let expected = expected_price(FOUR_LETTER_PRICE, 5);
+    let (_ctx, ok) = register_for(5, expected - 1).await?;
+    assert!(!ok, "paying one unit under the discounted price must fail");
+    Ok(())
+}

--- a/tests/naming_overflow_tests.rs
+++ b/tests/naming_overflow_tests.rs
@@ -1,0 +1,287 @@
+//! Regression tests for the u32 overflow that bricked registration once the registry vault
+//! balance crossed `u32::MAX`. `_receive_payment` and `_get_remaining_revenue` used
+//! `u32overflowing_sub` on values that are felts by protocol construction (asset amounts are
+//! capped at 2^63 - 2^31), so the VM's u32 range check trapped before any arithmetic ran.
+//!
+//! These tests use a price table where every price already exceeds `u32::MAX`, so a single
+//! registration pushes the vault past the old limit.
+
+mod test_utils;
+
+use miden_client::{
+    asset::FungibleAsset,
+    note::{NoteAssets, NoteStorage, NoteTag, NoteType},
+};
+use miden_crypto::{Felt, Word};
+use midenname_contracts::domain::{encode_domain, encode_domain_as_felts, reverse_word};
+use midenname_contracts::storage::slot_name;
+use miden_protocol::transaction::RawOutputNote;
+
+use crate::test_utils::{
+    add_note_to_builder, create_note_for_naming, create_p2id_note_exact, execute_note,
+    execute_note_with_expected_output, execute_notes_and_build_chain, init_naming_with,
+};
+
+/// Matches `masm/notes/set_all_prices_high.masm`.
+const FOUR_LETTER_PRICE: u64 = 6_000_000_000;
+const FIVE_LETTER_PRICE: u64 = 5_000_000_000;
+const U32_MAX: u64 = u32::MAX as u64;
+
+/// Enough to pay for both registrations in the multi-registration test.
+const REGISTRAR_FUNDING: u64 = 20_000_000_000;
+
+fn register_inputs(
+    faucet: miden_client::account::AccountId,
+    domain: &[Felt],
+) -> anyhow::Result<NoteStorage> {
+    Ok(NoteStorage::new(
+        [
+            faucet.suffix(),
+            faucet.prefix().as_felt(),
+            Felt::new(0)?,
+            Felt::new(0)?,
+            domain[0],
+            domain[1],
+            domain[2],
+            domain[3],
+        ]
+        .to_vec(),
+    )?)
+}
+
+fn revenue_key(faucet: miden_client::account::AccountId) -> anyhow::Result<Word> {
+    Ok(Word::new([
+        faucet.suffix(),
+        faucet.prefix().as_felt(),
+        Felt::new(0)?,
+        Felt::new(0)?,
+    ]))
+}
+
+/// A single registration takes the vault from 0 to above `u32::MAX`. Under the old
+/// `u32overflowing_sub` this trapped on `after_bal`.
+#[tokio::test]
+async fn test_register_when_balance_crosses_u32_max() -> anyhow::Result<()> {
+    let mut ctx = init_naming_with(REGISTRAR_FUNDING, "set_all_prices_high").await?;
+    let faucet = ctx.fungible_asset.faucet_id();
+
+    let domain = encode_domain_as_felts("test".to_string());
+    let domain_word = encode_domain("test".to_string());
+
+    let cost = FungibleAsset::new(faucet, FOUR_LETTER_PRICE)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(),
+        register_inputs(faucet, &domain)?,
+        ctx.registrar_1.id(),
+        ctx.naming.id(),
+        NoteAssets::new(vec![cost.into()])?,
+    )
+    .await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    execute_notes_and_build_chain(
+        ctx.builder,
+        &[
+            ctx.initialize_note.id(),
+            ctx.set_prices_note.id(),
+            register_note.id(),
+        ],
+        &mut ctx.naming,
+    )
+    .await?;
+
+    assert!(
+        FOUR_LETTER_PRICE > U32_MAX,
+        "test is meaningless unless the price alone exceeds u32::MAX"
+    );
+
+    // Domain ownership was recorded, so _receive_payment accepted the payment.
+    let domain_owner = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::domain_to_owner"), reverse_word(domain_word))?,
+    );
+    assert_eq!(
+        domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_1.id().suffix().as_canonical_u64()
+    );
+
+    // Revenue accumulated at full felt width.
+    let total_revenue = reverse_word(ctx.naming.storage().get_map_item(
+        &slot_name("naming::total_revenue"),
+        reverse_word(revenue_key(faucet)?),
+    )?);
+    assert_eq!(
+        total_revenue.get(0).unwrap().as_canonical_u64(),
+        FOUR_LETTER_PRICE
+    );
+
+    Ok(())
+}
+
+/// The second registration runs with `before_bal` already above `u32::MAX`, which is the state
+/// the live registry was stuck in — both operands of the old subtraction were out of range.
+#[tokio::test]
+async fn test_register_when_balance_already_above_u32_max() -> anyhow::Result<()> {
+    let mut ctx = init_naming_with(REGISTRAR_FUNDING, "set_all_prices_high").await?;
+    let faucet = ctx.fungible_asset.faucet_id();
+
+    let first_domain = encode_domain_as_felts("test".to_string());
+    let first_note = create_note_for_naming(
+        "register_name".to_string(),
+        register_inputs(faucet, &first_domain)?,
+        ctx.registrar_1.id(),
+        ctx.naming.id(),
+        NoteAssets::new(vec![FungibleAsset::new(faucet, FOUR_LETTER_PRICE)?.into()])?,
+    )
+    .await?;
+    add_note_to_builder(&mut ctx.builder, first_note.clone())?;
+
+    let second_domain = encode_domain_as_felts("abcde".to_string());
+    let second_domain_word = encode_domain("abcde".to_string());
+    let second_note = create_note_for_naming(
+        "register_name".to_string(),
+        register_inputs(faucet, &second_domain)?,
+        ctx.registrar_1.id(),
+        ctx.naming.id(),
+        NoteAssets::new(vec![FungibleAsset::new(faucet, FIVE_LETTER_PRICE)?.into()])?,
+    )
+    .await?;
+    add_note_to_builder(&mut ctx.builder, second_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[
+            ctx.initialize_note.id(),
+            ctx.set_prices_note.id(),
+            first_note.id(),
+        ],
+        &mut ctx.naming,
+    )
+    .await?;
+
+    // Vault now holds FOUR_LETTER_PRICE (> u32::MAX); this second payment reads it as before_bal.
+    execute_note(&mut chain, second_note.id(), &mut ctx.naming).await?;
+
+    let domain_owner = reverse_word(ctx.naming.storage().get_map_item(
+        &slot_name("naming::domain_to_owner"),
+        reverse_word(second_domain_word),
+    )?);
+    assert_eq!(
+        domain_owner.get(1).unwrap().as_canonical_u64(),
+        ctx.registrar_1.id().suffix().as_canonical_u64()
+    );
+
+    let total_revenue = reverse_word(ctx.naming.storage().get_map_item(
+        &slot_name("naming::total_revenue"),
+        reverse_word(revenue_key(faucet)?),
+    )?);
+    assert_eq!(
+        total_revenue.get(0).unwrap().as_canonical_u64(),
+        FOUR_LETTER_PRICE + FIVE_LETTER_PRICE
+    );
+
+    Ok(())
+}
+
+/// `_get_remaining_revenue` subtracts claimed from total revenue. Both accumulate as felts, so
+/// the old u32 subtraction bricked revenue claims permanently once cumulative revenue crossed
+/// `u32::MAX` (unlike the vault balance, total_revenue can never be brought back down).
+#[tokio::test]
+async fn test_claim_protocol_revenue_above_u32_max() -> anyhow::Result<()> {
+    let mut ctx = init_naming_with(REGISTRAR_FUNDING, "set_all_prices_high").await?;
+    let faucet = ctx.fungible_asset.faucet_id();
+
+    let domain = encode_domain_as_felts("test".to_string());
+    let cost = FungibleAsset::new(faucet, FOUR_LETTER_PRICE)?;
+    let register_note = create_note_for_naming(
+        "register_name".to_string(),
+        register_inputs(faucet, &domain)?,
+        ctx.registrar_1.id(),
+        ctx.naming.id(),
+        NoteAssets::new(vec![cost.into()])?,
+    )
+    .await?;
+    add_note_to_builder(&mut ctx.builder, register_note.clone())?;
+
+    // The claim pays the whole accumulated revenue out to the owner via P2ID.
+    let p2id_note = create_p2id_note_exact(
+        ctx.naming.id(),
+        ctx.owner.id(),
+        vec![cost.into()],
+        NoteType::Public,
+        Word::default(),
+    )?;
+    let p2id_recipient = p2id_note.recipient().digest();
+    let tag = NoteTag::with_account_target(ctx.owner.id());
+
+    let claim_note_inputs = NoteStorage::new(
+        [
+            // RECIPIENT (0-3), passed reversed for the contract's mem_loadw_be.
+            p2id_recipient[3],
+            p2id_recipient[2],
+            p2id_recipient[1],
+            p2id_recipient[0],
+            // NOTE_DETAILS (4-7): note_type, tag, padding, padding
+            NoteType::Public.into(),
+            tag.into(),
+            Felt::new(0)?,
+            Felt::new(0)?,
+            // TOKEN (8-11)
+            faucet.suffix(),
+            faucet.prefix().as_felt(),
+            Felt::new(0)?,
+            Felt::new(0)?,
+        ]
+        .to_vec(),
+    )?;
+    let claim_note = create_note_for_naming(
+        "claim_protocol_revenue".to_string(),
+        claim_note_inputs,
+        ctx.owner.id(),
+        ctx.naming.id(),
+        NoteAssets::new(vec![])?,
+    )
+    .await?;
+    add_note_to_builder(&mut ctx.builder, claim_note.clone())?;
+
+    let mut chain = execute_notes_and_build_chain(
+        ctx.builder,
+        &[
+            ctx.initialize_note.id(),
+            ctx.set_prices_note.id(),
+            register_note.id(),
+        ],
+        &mut ctx.naming,
+    )
+    .await?;
+    execute_note_with_expected_output(
+        &mut chain,
+        claim_note.id(),
+        &mut ctx.naming,
+        vec![RawOutputNote::Full(p2id_note)],
+    )
+    .await?;
+
+    let key = revenue_key(faucet)?;
+    let total_revenue = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::total_revenue"), reverse_word(key))?,
+    );
+    let claimed_revenue = reverse_word(
+        ctx.naming
+            .storage()
+            .get_map_item(&slot_name("naming::claimed_revenue"), reverse_word(key))?,
+    );
+    assert_eq!(
+        total_revenue.get(0).unwrap().as_canonical_u64(),
+        FOUR_LETTER_PRICE
+    );
+    assert_eq!(
+        claimed_revenue.get(0).unwrap().as_canonical_u64(),
+        FOUR_LETTER_PRICE
+    );
+
+    Ok(())
+}

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -26,9 +26,19 @@ use midenname_contracts::storage::naming_storage;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
+/// Path of the contract variant the plain (non-`_with_contract`) helpers build against.
+pub const NAMING_CONTRACT: &str = "./masm/accounts/naming.masm";
+pub const NAMING_DISCOUNT_CONTRACT: &str = "./masm/accounts/naming_discount.masm";
+
 pub fn create_test_naming_account() -> Account {
+    create_test_account_from(NAMING_CONTRACT)
+}
+
+/// Builds a test account from any of the naming contract variants. They all share
+/// [`naming_storage`], so only the code differs.
+pub fn create_test_account_from(contract_path: &str) -> Account {
     let storage_slots = naming_storage();
-    let code = fs::read_to_string(Path::new("./masm/accounts/naming.masm")).unwrap();
+    let code = fs::read_to_string(Path::new(contract_path)).unwrap();
 
     let source_manager = Arc::new(DefaultSourceManager::default());
     let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone())
@@ -63,8 +73,22 @@ pub async fn create_note_for_naming(
     target_id: AccountId,
     assets: NoteAssets,
 ) -> anyhow::Result<Note> {
+    create_note_for_naming_with_contract(name, inputs, sender, target_id, assets, NAMING_CONTRACT)
+        .await
+}
+
+/// Same as [`create_note_for_naming`] but links the note script against a chosen contract
+/// variant, so notes can target the discount contract's procedure signatures.
+pub async fn create_note_for_naming_with_contract(
+    name: String,
+    inputs: NoteStorage,
+    sender: AccountId,
+    target_id: AccountId,
+    assets: NoteAssets,
+    contract_path: &str,
+) -> anyhow::Result<Note> {
     let note_code = fs::read_to_string(Path::new(&format!("./masm/notes/{}.masm", name)))?;
-    let naming_code = fs::read_to_string(Path::new("./masm/accounts/naming.masm")).unwrap();
+    let naming_code = fs::read_to_string(Path::new(contract_path)).unwrap();
     let library = create_library(naming_code, "miden_name::naming")?;
 
     let note_script = CodeBuilder::default()
@@ -148,10 +172,19 @@ pub struct TestingContext {
 }
 
 pub async fn init_naming() -> anyhow::Result<TestingContext> {
+    init_naming_with(100000, "set_all_prices").await
+}
+
+/// Same as [`init_naming`] but lets a test choose how much registrar_1 is funded with and which
+/// price-table note is used. Needed to exercise balances and prices above `u32::MAX`.
+pub async fn init_naming_with(
+    registrar_1_funding: u64,
+    prices_note: &str,
+) -> anyhow::Result<TestingContext> {
     let mut builder = MockChain::builder();
     let fungible_asset_1 = FungibleAsset::new(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1.try_into().unwrap(),
-        100000,
+        registrar_1_funding,
     )
     .unwrap();
     let fungible_asset_2 = FungibleAsset::new(
@@ -218,7 +251,7 @@ pub async fn init_naming() -> anyhow::Result<TestingContext> {
         .to_vec(),
     )?;
     let set_prices_note = create_note_for_naming(
-        "set_all_prices".to_string(),
+        prices_note.to_string(),
         note_inputs,
         owner_account.id(),
         naming_account.id(),


### PR DESCRIPTION
## Problem

Registration on the testnet registry started failing for everyone with:

```
operation expected u32 values, but got values: [4305000000]
```

That value is the registry vault balance after payment (4,285,000,000 + a 20,000,000 fee), about 10M over `u32::MAX`. It is a width bug, not a wallet or frontend issue.

`_receive_payment` validated payment with `u32overflowing_sub` on the vault balance, and `_get_remaining_revenue` did the same on accumulated revenue. Both are felt-width by protocol construction — `AssetAmount::MAX` is `2^63 - 2^31`, chosen so an amount always fits in a field element. The VM range-checks **both** operands of a u32 op, so once the vault crossed `u32::MAX` (~4295 MIDEN at 6 decimals) the operation trapped before any arithmetic ran.

This is a threshold bug on an accumulating balance: it works until cumulative fees cross the limit, then breaks for every caller at once. Nothing changed in the frontend — the registry simply filled up.

## Fix

Both sites now use felt arithmetic. `sub` compiles to `[Neg, Add]`, so it takes `[b, a] → a - b` — the same operand order as `u32overflowing_sub`, making it a drop-in. The following `lte` was already a full-field comparison and is unchanged.

`_receive_payment` drops its overflow guard, which was protecting an unreachable case (`add_assets_to_account` can only increase the balance). `_get_remaining_revenue` keeps an explicit `gte` guard, since a violated `claimed <= total` invariant would otherwise wrap silently.

The revenue site matters independently. `total_revenue` only ever grows and `_set_claimed_to_total` is reachable only *through* the trapping procedure, so crossing the limit bricked revenue claims permanently, with no recovery path. Vault balance can at least be drained via `withdraw_assets`, which uses no u32 ops.

## naming_discount.masm

This variant had never moved past 0.13 and **did not assemble at all** — `u32overflowing_mul` was removed in Miden 0.23. It now carries the 0.15 asset model (8-felt `ASSET_KEY`/`ASSET_VALUE` pairs, `create_fungible_key`, `create_fungible_asset`), the `get_sender` operand order, and implementations for the previously stubbed `claim_protocol_revenue` and `withdraw_assets`.

Its fee math was wrong at any realistic price: `price * 5000bp` on a 6e9 price is 3e13, roughly 7000× `u32::MAX`. The multiply is now felt-width and the divide goes through `miden::core::math::u64`, in a shared `_apply_basis_points` helper. Prices are bounded to < 2^48 by `_assert_price_in_range`, keeping `price * MAX_REF_RATE` under 2^62 and `price * MAX_REG_LEN` under 2^52 — both well inside the field. Timestamp math is felt with a closing `u32assert`.

Two checks were added beyond a pure translation, because the felt arithmetic is not safe without them: the `MAX_REG_LEN` bound in `_calculate_domain_price` and `_extend_existing_domain_length` (previously only `_update_domain_length` checked it, so `extend_domain` could multiply by an unbounded `reg_len`), and explicit underflow guards where felt `sub` would otherwise wrap.

## Tests

- **`naming_overflow_tests.rs`** — registration crossing `u32::MAX`, a second registration with *both* operands already out of range (the state the live registry was stuck in), and a revenue claim above the limit. All three fail on the pre-fix contract with the exact production error, and pass after.
- **`naming_discount_tests.rs`** — first runtime coverage this contract has ever had. Asserts exact charged prices for the 3-year (12,600,000,000) and 5-year (15,000,000,000) discounts, plus underpayment rejection.
- **`masm_assembly_tests.rs`** — asserts each variant assembles. Nothing else instantiates `naming_unsafe` or `naming_discount`, which is why the broken discount contract went unnoticed.

Full suite: **43 passed, 0 failed, 2 pre-existing ignored.**
